### PR TITLE
chore: add proper shebang to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
-if [[ "$OS" == "Windows_NT" ]]; then
+#!/usr/bin/env sh
+if [ "$OS" = "Windows_NT" ]; then
   LINK_OPTS=-Wl,--export-all
 else
   LINK_OPTS=-rdynamic


### PR DESCRIPTION
Should probably be added to all other shell scripts as well, but this is the most prominent one since it's mentioned in the README and it uses Bash features, so it will break when not called from Bash.