### PR TITLE
feat: add support for glob targets

### DIFF
--- a/Lake/Glob.lean
+++ b/Lake/Glob.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Data.Name
+import Lean.Elab.Import
+
+open System (FilePath)
+open Lean (Name)
+
+namespace Lake
+
+/--
+  A specification of a set of module names to build.
+-/
+inductive Glob
+  | /-- Builds the specified module name -/
+    one : Name → Glob
+  | /-- Builds the specified module and all submodules -/
+    andSubdirs : Name → Glob
+  | /--
+      Builds all submodules of the specified module,
+      without building the module itself
+    -/
+    subdirs : Name → Glob
+
+instance : Coe Name Glob := ⟨Glob.one⟩
+
+-- TODO(Mario): Rename Lean.modToFilePath.go to modToDir
+def modToDir (base : FilePath) : Name → FilePath
+  | Name.str p h _ => modToDir base p / h
+  | Name.anonymous => base
+  | Name.num p _ _ => panic! "ill-formed import"
+
+partial def directoryTraversal [Monad m] [MonadLiftT IO m]
+  (base : FilePath) (push : FilePath → m PUnit) : m PUnit := do
+  for entry in ← base.readDir do
+    let path := entry.path
+    if (← path.isDir : Bool) then
+      directoryTraversal path push
+    else
+      push path
+
+def onSubdirectoryFilesWithExt [Monad m] [MonadLiftT IO m]
+  (base : FilePath) (ext : String) (push : FilePath → m PUnit) : m PUnit :=
+  directoryTraversal base fun file => do
+    if file.extension == some ext then
+      push file
+
+def Glob.pushFilePaths [Monad m] [MonadLiftT IO m]
+  (base : FilePath) (ext : String) (push : FilePath → m PUnit) :
+  Glob → m PUnit
+  | Glob.one n => push $ modToDir base n |>.withExtension ext
+  | Glob.subdirs n =>
+    let dir := modToDir base n
+    onSubdirectoryFilesWithExt base ext push
+  | Glob.andSubdirs n => do
+    let dir := modToDir base n
+    onSubdirectoryFilesWithExt base ext push
+    push $ dir.withExtension ext
+
+def globsToFilePaths (base : FilePath) (ext : String)
+  (globs : List Glob) : IO (Array FilePath) := do
+  let arr ← IO.mkRef #[]
+  for glob in globs do
+    glob.pushFilePaths base ext fun file => arr.modify (·.push file)
+  arr.get

--- a/Lake/Package.lean
+++ b/Lake/Package.lean
@@ -8,6 +8,7 @@ import Lean.Elab.Import
 import Std.Data.HashMap
 import Lake.LeanVersion
 import Lake.BuildTarget
+import Lake.Glob
 
 open Std System
 open Lean (Name)
@@ -179,6 +180,12 @@ structure PackageConfig where
     Defaults to the string representation of the package's `moduleRoot`.
   -/
   libName : String := moduleRoot.toString (escape := false)
+
+  /--
+    The list of modules or module globs to build for the library target.
+    Defaults to building the package's `moduleRoot` (and dependencies).
+  -/
+  libModules : List Glob := [moduleRoot]
 
   /--
     The build subdirectory to which Lake should output the package's static library.
@@ -378,6 +385,10 @@ def binFile (self : Package) : FilePath :=
 /-- The package's `buildDir` joined with its configuration's `libDir`. -/
 def libDir (self : Package) : FilePath :=
   self.buildDir / self.config.libDir
+
+/-- The package's `libModules` configuration. -/
+def libModules (self : Package) : List Glob :=
+  self.config.libModules
 
 /-- The package's `libName` configuration. -/
 def staticLibName (self : Package) : FilePath :=


### PR DESCRIPTION
This PR does not build yet; there is more work to call  `globsToFilePaths` in appropriate locations. Additionally the `libTargets` and `binTargets` need review / adjustment. I'm not sure how to work this into functions like `buildModuleOleanAndCTargetsWithDepTargets` yet.