### PR TITLE
fix: syntax/mathlib name in dependencies example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ For example, one can depend on the Lean 4 port of [mathlib](https://github.com/l
 
 ```lean
 package hello {
-  dependencies = #[{
-    name := `mathlib4
+  dependencies := #[{
+    name := `mathlib
     src := Source.git "https://github.com/leanprover-community/mathlib4.git" "master"
   }]
 }


### PR DESCRIPTION
Mathlib4 changed the package name to just `mathlib`. Trying to build
with a dependency name `mathlib4 will now cause an error.