### PR TITLE
fix: serve: fall back to `lean --server` on error

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-01-17
+leanprover/lean4:nightly-2022-02-04


### PR DESCRIPTION
If `lake serve` fails to parse the `lakefile.lean`, fall back to running `lean --server` without additional environment variables or more lakefile-specified server arguments.  In this fallback mode, all files except `lakefile.lean` immediately fail with an error to remind the user that `lake serve` must be restarted after fixing `lakefile.lean`.

Fixes #49.