### PR TITLE
perf: do not import Lean.Elab.Frontend from Lake

### DIFF
--- a/Lake.lean
+++ b/Lake.lean
@@ -6,5 +6,4 @@ Authors: Mac Malone
 import Lake.Build
 import Lake.Config
 import Lake.DSL
-import Lake.CLI
 import Lake.Version

--- a/Lake/Config.lean
+++ b/Lake/Config.lean
@@ -10,6 +10,4 @@ import Lake.Config.Script
 import Lake.Config.Package
 import Lake.Config.Monad
 import Lake.Config.SearchPath
-import Lake.Config.Resolve
-import Lake.Config.Load
 import Lake.Config.Util

--- a/Lake/Config/Glob.lean
+++ b/Lake/Config/Glob.lean
@@ -3,8 +3,7 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Mac Malone
 -/
-import Lean.Data.Name
-import Lean.Elab.Import
+import Lean.Util.Path
 
 open Lean (Name)
 open System (FilePath)

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -3,8 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Sebastian Ullrich, Mac Malone
 -/
-import Lean.Data.Name
-import Lean.Elab.Import
 import Std.Data.HashMap
 import Lake.Build.TargetTypes
 import Lake.Config.Glob

--- a/Lake/DSL/Commands.lean
+++ b/Lake/DSL/Commands.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Mac Malone. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mac Malone
 -/
-import Lean.Parser
+import Lean.Parser.Command
 import Lake.Config.Package
 import Lake.DSL.Attributes
 

--- a/Lake/Main.lean
+++ b/Lake/Main.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Sebastian Ullrich, Mac Malone
 -/
 import Lake
+import Lake.CLI
 
 def main (args : List String) : IO UInt32 := do
   Lake.cli args -- should not throw errors (outside user code)


### PR DESCRIPTION
This reduces the runtime of `lake env true` by 40% on doc-gen4.