### PR TITLE
fix: do not suppress git output

### DIFF
--- a/Lake/Util/Git.lean
+++ b/Lake/Util/Git.lean
@@ -17,7 +17,7 @@ def defaultRevision : Option String → String
 def execGit (args : Array String) (repo : Option FilePath := none) : IO PUnit := do
   let child ← IO.Process.spawn {
     cmd := "git", args, cwd := repo,
-    stdout := IO.Process.Stdio.null, stderr := IO.Process.Stdio.null
+    stdout := IO.Process.Stdio.null
   }
   let exitCode ← child.wait
   if exitCode != 0 then


### PR DESCRIPTION
This makes it easier to debug cases where git fails.  The stderr output also shows progress information during git clone.

See https://github.com/leanprover/lake/issues/31#issuecomment-1006700638
Split off from #64