### PR TITLE
fix: git should ignore example build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 result*
 # Do not commit the flake lockfile to avoid having to maintain it
 flake.lock
+/examples/**/build/


### PR DESCRIPTION
Currently if I build lake, I get a bunch of git-untracked build files in examples/ffi/build/ and examples/ffi-dep/build/. These build directories should be in gitignore. I think ignoring `build/` is wrong or confusing because there is a `Lake/Build/` directory.