### PR TITLE
perf: do not build object files of imports when linking executable

### DIFF
--- a/Lake/Build/Roots.lean
+++ b/Lake/Build/Roots.lean
@@ -81,9 +81,9 @@ def LeanLib.recBuildShared (self : LeanLib) : IndexT m ActiveFileTarget := do
 def LeanExe.recBuild (self : LeanExe) : IndexT m ActiveFileTarget := do
   have : MonadLift BuildM m := ⟨liftM⟩
   let (_, imports) ← self.root.imports.recBuild
-  let linkTargets := #[Target.active <| ← self.root.o.recBuild]
+  let linkTargets := #[Target.active <| ← self.root.c.recBuild]
   let mut linkTargets ← imports.foldlM (init := linkTargets) fun arr mod => do
-    return arr.push <| Target.active <| ← mod.o.recBuild
+    return arr.push <| Target.active <| ← mod.c.recBuild
   let deps := (← recBuild <| self.pkg.facet &`deps).push self.pkg
   for dep in deps do for lib in dep.externLibs do
     linkTargets := linkTargets.push <| Target.active <| ← lib.static.recBuild

--- a/Lake/Build/Roots.lean
+++ b/Lake/Build/Roots.lean
@@ -81,7 +81,7 @@ def LeanLib.recBuildShared (self : LeanLib) : IndexT m ActiveFileTarget := do
 def LeanExe.recBuild (self : LeanExe) : IndexT m ActiveFileTarget := do
   have : MonadLift BuildM m := ⟨liftM⟩
   let (_, imports) ← self.root.imports.recBuild
-  let linkTargets := #[Target.active <| ← self.root.c.recBuild]
+  let linkTargets := #[Target.active <| ← self.root.o.recBuild]
   let mut linkTargets ← imports.foldlM (init := linkTargets) fun arr mod => do
     return arr.push <| Target.active <| ← mod.c.recBuild
   let deps := (← recBuild <| self.pkg.facet &`deps).push self.pkg


### PR DESCRIPTION
For some reason, linking the C files directly seems to cut the Lake's build time of such executables in half.

If I may ask, @Kha, is there something about `leanc`/`clang` that makes this more efficient? Or is this likely some bottleneck in Lake that I am missing?