### PR TITLE
Add example of syntax of Array Name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ package hello {
 
 lean_lib Hello {
   -- add library configuration options here
+  srcDir := "."
+  -- this is the syntax for `Array`
+  roots := #[
+    -- this is the syntax for `Name`
+    `Hello
+  ]
 }
 
 @[defaultTarget]


### PR DESCRIPTION
It's weird that nowhere in Readme mentioned the syntax for `Array Name`.

It took me a Github advanced search to find the syntax `#[ \`id ]`.

It is very weird. Why not just use `List Name` for the type?