### PR TITLE
feat: FacetConfig in Type 0

### DIFF
--- a/Lake/CLI/Build.lean
+++ b/Lake/CLI/Build.lean
@@ -39,9 +39,8 @@ def resolveModuleTarget (ws : Workspace) (mod : Module) (facet : Name) : Except 
   else if facet == `dynlib then
     return mod.facetTarget dynlibFacet
   else if let some config := ws.findModuleFacetConfig? facet then
-    if let some (.up ⟨_, h⟩) := config.result_eq_target? then
-      have := config.familyDefTarget h
-      return mod.facetTarget facet
+    if let some target := config.target? then
+      return target (mod.facet facet) rfl
     else
       throw <| CliError.nonTargetFacet "module" facet
   else
@@ -106,9 +105,8 @@ def resolvePackageTarget (ws : Workspace) (pkg : Package) (facet : Name) : Excep
   else if facet == `leanLib then
     return pkg.leanLibTarget.withoutInfo
   else if let some config := ws.findPackageFacetConfig? facet then
-    if let some (.up ⟨_, h⟩) := config.result_eq_target? then
-      have := config.familyDefTarget h
-      return pkg.facet facet |>.target
+    if let some target := config.target? then
+      return target (pkg.facet facet) rfl
     else
       throw <| CliError.nonTargetFacet "package" facet
   else

--- a/Lake/DSL/Facets.lean
+++ b/Lake/DSL/Facets.lean
@@ -6,6 +6,7 @@ Authors: Mac Malone
 import Lake.DSL.DeclUtil
 import Lake.Config.FacetConfig
 import Lake.Config.TargetConfig
+import Lake.Build.Index
 
 /-!
 Macros for declaring custom facets and targets.
@@ -26,11 +27,11 @@ kw:"module_facet " sig:simpleDeclSig : command => do
     `(module_data $id : ActiveBuildTarget $ty
       $[$doc?]? @[$attrs,*] def $id : ModuleFacetDecl := {
         name := $name
-        config := {
+        config := mkFacetConfig {
           resultType := ActiveBuildTarget $ty
           build := $defn
           data_eq_result := $axm
-          result_eq_target? := some (.up ⟨$ty, rfl⟩)
+          result_eq_target? := some ⟨$ty, rfl⟩
         }
       })
   | stx => Macro.throwErrorAt stx "ill-formed module facet declaration"
@@ -47,11 +48,11 @@ kw:"package_facet " sig:simpleDeclSig : command => do
     `(package_data $id : ActiveBuildTarget $ty
       $[$doc?]? @[$attrs,*] def $id : PackageFacetDecl := {
         name := $name
-        config := {
+        config := mkFacetConfig {
           resultType := ActiveBuildTarget $ty
           build := $defn
           data_eq_result := $axm
-          result_eq_target? := some (.up ⟨$ty, rfl⟩)
+          result_eq_target? := some ⟨$ty, rfl⟩
         }
       })
   | stx => Macro.throwErrorAt stx "ill-formed package facet declaration"


### PR DESCRIPTION
An experimental refactor of `FacetConfig` to avoid the universe bumping issues mentioned on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/universe.20polymorphic.20IO). Summary of changes:

* The `FacetConfig.build` function is monad-generic, but it is only ever used at one monad. By inlining the specific monad that is required, we avoid a universe bump.
  * Introduced the `BuildStoreM` and `BuildConfigM` monads to name this `m` monad. These names are probably terrible and I cannot claim to understand what all is going on here.
* The `FacetConfig.resultType` type is superfluous, since it has an axiom saying it is equal to a function of the parameters. By inlining it we avoid another universe bump.
* The `FacetConfig.result_eq_target?` value is an `Option {α : Type // resultType = ActiveBuildTarget α}`, which also causes a universe bump. To fix this one, we precompute the only function we will call on the value, `BuildInfo.target`, so we are only storing a `BuildInfo → OpaqueTarget` which does not require a universe bump. The type equality is required for one of the downstream functions to typecheck, and after inlining everything the requisite condition turns out to be `BuildData info.key = DataFam name`.
* It is not entirely clear to me who is constructing elements of `FacetConfig`. If it is an API type, then we need to retain the original form for convenience and backward compatibility. To that end, I added a `FacetConfig'` type which is roughly the original `FacetConfig` (and lives in `Type 1`), along with a smart constructor `mkFacetConfig` which takes `FacetConfig'` and produces `FacetConfig` (which is in `Type 0`). The latter can thus be used to store configs in data structures without a universe bump, while retaining the convenience of the higher order API type `FacetConfig'`. (All of the names should be considered as placeholders. I have no qualms with changing any of them.)