### PR TITLE
feat: put command invocations under --verbose flag

### DIFF
--- a/Lake/Build/Actions.lean
+++ b/Lake/Build/Actions.lean
@@ -16,7 +16,7 @@ def proc (args : IO.Process.SpawnArgs) : JobM Unit := do
   let envStr := String.join <| args.env.toList.filterMap fun (k, v) =>
     if k == "PATH" then none else some s!"{k}={v.getD ""} " -- PATH too big
   let cmdStr := " ".intercalate (args.cmd :: args.args.toList)
-  logInfo <| "> " ++ envStr ++
+  logVerbose <| "> " ++ envStr ++
     match args.cwd with
     | some cwd => s!"{cmdStr}    # in directory {cwd}"
     | none     => cmdStr

--- a/Lake/Build/Actions.lean
+++ b/Lake/Build/Actions.lean
@@ -33,12 +33,13 @@ def proc (args : IO.Process.SpawnArgs) : JobM Unit := do
     logError s!"external command {args.cmd} exited with status {out.exitCode}"
     failure
 
-def compileLeanModule (leanFile : FilePath)
+def compileLeanModule (name : Name) (leanFile : FilePath)
 (oleanFile? ileanFile? cFile? : Option FilePath)
 (leanPath : SearchPath := []) (rootDir : FilePath := ".")
 (dynlibs : Array FilePath := #[]) (dynlibPath : SearchPath := {})
 (leanArgs : Array String := #[]) (lean : FilePath := "lean")
 : JobM PUnit := do
+  logAuxInfo s!"Building {name}"
   let mut args := leanArgs ++
     #[leanFile.toString, "-R", rootDir.toString]
   if let some oleanFile := oleanFile? then
@@ -61,32 +62,36 @@ def compileLeanModule (leanFile : FilePath)
     ]
   }
 
-def compileO (oFile srcFile : FilePath)
+def compileO (name : Name) (oFile srcFile : FilePath)
 (moreArgs : Array String := #[]) (compiler : FilePath := "cc") : JobM Unit := do
+  logAuxInfo s!"Compiling {name}"
   createParentDirs oFile
   proc {
     cmd := compiler.toString
     args := #["-c", "-o", oFile.toString, srcFile.toString] ++ moreArgs
   }
 
-def compileStaticLib (libFile : FilePath)
+def compileStaticLib (name : Name) (libFile : FilePath)
 (oFiles : Array FilePath) (ar : FilePath := "ar") : JobM Unit := do
+  logAuxInfo s!"Linking {name}"
   createParentDirs libFile
   proc {
     cmd := ar.toString
     args := #["rcs", libFile.toString] ++ oFiles.map toString
   }
 
-def compileSharedLib (libFile : FilePath)
+def compileSharedLib (name : Name) (libFile : FilePath)
 (linkArgs : Array String) (linker : FilePath := "cc") : JobM Unit := do
+  logAuxInfo s!"Linking {name}"
   createParentDirs libFile
   proc {
     cmd := linker.toString
     args := #["-shared", "-o", libFile.toString] ++ linkArgs
   }
 
-def compileExe (binFile : FilePath) (linkFiles : Array FilePath)
+def compileExe (name : Name) (binFile : FilePath) (linkFiles : Array FilePath)
 (linkArgs : Array String := #[]) (linker : FilePath := "cc") : JobM Unit := do
+  logAuxInfo s!"Linking {name}"
   createParentDirs binFile
   proc {
     cmd := linker.toString

--- a/Lake/Build/Executable.lean
+++ b/Lake/Build/Executable.lean
@@ -21,4 +21,4 @@ protected def LeanExe.recBuildExe
   let deps := (← recBuild <| self.pkg.facet `deps).push self.pkg
   for dep in deps do for lib in dep.externLibs do
     linkTargets := linkTargets.push <| Target.active <| ← lib.static.recBuild
-  leanExeTarget self.file linkTargets self.linkArgs |>.activate
+  leanExeTarget self.name self.file linkTargets self.linkArgs |>.activate

--- a/Lake/Build/Index.lean
+++ b/Lake/Build/Index.lean
@@ -59,7 +59,7 @@ def recBuildWithIndex : (info : BuildInfo) → IndexBuildM (BuildData info.key)
 | .sharedExternLib lib =>
   mkTargetFacetBuild ExternLib.sharedFacet do
     let staticTarget := Target.active <| ← lib.static.recBuild
-    staticToLeanSharedLibTarget staticTarget |>.activate
+    staticToLeanSharedLibTarget lib.name staticTarget |>.activate
 | .dynlibExternLib lib =>
   mkTargetFacetBuild ExternLib.dynlibFacet do
     let sharedTarget := Target.active <| ← lib.shared.recBuild

--- a/Lake/Build/Library.lean
+++ b/Lake/Build/Library.lean
@@ -37,7 +37,7 @@ def LeanLib.leanFacetConfig : LibraryFacetConfig leanFacet :=
 protected def LeanLib.recBuildStatic
 (self : LeanLib) : IndexBuildM (BuildJob FilePath) := do
   let oTargets := (← self.recBuildLocalModules self.nativeFacets).map Target.active
-  staticLibTarget self.staticLibFile oTargets |>.activate
+  staticLibTarget self.name self.staticLibFile oTargets |>.activate
 
 /-- The `LibraryFacetConfig` for the builtin `staticFacet`. -/
 def LeanLib.staticFacetConfig : LibraryFacetConfig staticFacet :=
@@ -79,7 +79,7 @@ def LeanLib.recBuildLinks
 protected def LeanLib.recBuildShared
 (self : LeanLib) : IndexBuildM (BuildJob FilePath) := do
   let linkJobs := (← self.recBuildLinks).map Target.active
-  leanSharedLibTarget self.sharedLibFile linkJobs self.linkArgs |>.activate
+  leanSharedLibTarget self.name self.sharedLibFile linkJobs self.linkArgs |>.activate
 
 /-- The `LibraryFacetConfig` for the builtin `sharedFacet`. -/
 def LeanLib.sharedFacetConfig : LibraryFacetConfig sharedFacet :=

--- a/Lake/Build/Module.lean
+++ b/Lake/Build/Module.lean
@@ -19,12 +19,12 @@ def Module.buildUnlessUpToDate (mod : Module)
   let modUpToDate ← modTrace.checkAgainstFile mod mod.traceFile
   if leanOnly then
     unless modUpToDate do
-      compileLeanModule mod.leanFile mod.oleanFile mod.ileanFile none
+      compileLeanModule mod.name mod.leanFile mod.oleanFile mod.ileanFile none
         (← getLeanPath) mod.rootDir dynlibs dynlibPath mod.leanArgs (← getLean)
   else
     let cUpToDate ← modTrace.checkAgainstFile mod.cFile mod.cTraceFile
     unless modUpToDate && cUpToDate do
-      compileLeanModule mod.leanFile mod.oleanFile mod.ileanFile mod.cFile
+      compileLeanModule mod.name mod.leanFile mod.oleanFile mod.ileanFile mod.cFile
         (← getLeanPath) mod.rootDir dynlibs dynlibPath mod.leanArgs (← getLean)
     modTrace.writeToFile mod.cTraceFile
   modTrace.writeToFile mod.traceFile
@@ -143,7 +143,7 @@ def Module.cFacetConfig : ModuleFacetConfig cFacet :=
 /-- Recursively build the module's object file from its C file produced by `lean`. -/
 def Module.recBuildLeanO (self : Module) : IndexBuildM (BuildJob FilePath) := do
   let cJob := Target.active (← self.c.recBuild)
-  leanOFileTarget self.oFile cJob self.leancArgs |>.activate
+  leanOFileTarget self.name self.oFile cJob self.leancArgs |>.activate
 
 /-- The `ModuleFacetConfig` for the builtin `oFacet`. -/
 def Module.oFacetConfig : ModuleFacetConfig oFacet :=
@@ -215,7 +215,7 @@ def Module.recBuildDynlib (mod : Module) : IndexBuildM (BuildJob String) := do
     let trace ← buildFileUnlessUpToDate mod.dynlibFile depTrace do
       let args := links.map toString ++
         libDirs.map (s!"-L{·}") ++ libNames.map (s!"-l{·}")
-      compileSharedLib mod.dynlibFile args (← getLeanc)
+      compileSharedLib mod.name mod.dynlibFile args (← getLeanc)
     return (mod.dynlibName, trace)
 
 /-- The `ModuleFacetConfig` for the builtin `dynlibFacet`. -/

--- a/Lake/CLI/Help.lean
+++ b/Lake/CLI/Help.lean
@@ -18,6 +18,7 @@ OPTIONS:
   --help, -h            print help of the program or a command and exit
   --dir, -d=file        use the package configuration in a specific directory
   --file, -f=file       use a specific file for the package configuration
+  --verbose, -v         show verbose information (command invocations)
   --lean=cmd            specify the `lean` command used by Lake
   -K key[=value]        set the configuration file option named key
 

--- a/Lake/CLI/Help.lean
+++ b/Lake/CLI/Help.lean
@@ -18,6 +18,7 @@ OPTIONS:
   --help, -h            print help of the program or a command and exit
   --dir, -d=file        use the package configuration in a specific directory
   --file, -f=file       use a specific file for the package configuration
+  --quiet, -q           hide progress messages
   --verbose, -v         show verbose information (command invocations)
   --lean=cmd            specify the `lean` command used by Lake
   -K key[=value]        set the configuration file option named key

--- a/Lake/CLI/Main.lean
+++ b/Lake/CLI/Main.lean
@@ -30,7 +30,7 @@ structure LakeOptions where
   configOpts : NameMap String := {}
   subArgs : List String := []
   wantsHelp : Bool := false
-  verbose : Bool := false
+  verbosity : Verbosity := .normal
 
 /-- Get the Lean installation. Error if missing. -/
 def LakeOptions.getLeanInstall (opts : LakeOptions) : Except CliError LeanInstall :=
@@ -61,7 +61,7 @@ def LakeOptions.mkLoadConfig
     configFile := opts.rootDir / opts.configFile
     configOpts := opts.configOpts
     leanOpts := Lean.Options.empty
-    verbose := opts.verbose
+    verbosity := opts.verbosity
     updateDeps
   }
 
@@ -121,7 +121,8 @@ def setConfigOpt (kvPair : String) : CliM PUnit :=
 
 def lakeShortOption : (opt : Char) → CliM PUnit
 | 'h' => modifyThe LakeOptions ({· with wantsHelp := true})
-| 'v' => modifyThe LakeOptions ({· with verbose := true})
+| 'q' => modifyThe LakeOptions ({· with verbosity := .quiet})
+| 'v' => modifyThe LakeOptions ({· with verbosity := .verbose})
 | 'd' => do let rootDir ← takeOptArg "-d" "path"; modifyThe LakeOptions ({· with rootDir})
 | 'f' => do let configFile ← takeOptArg "-f" "path"; modifyThe LakeOptions ({· with configFile})
 | 'K' => do setConfigOpt <| ← takeOptArg "-K" "key-value pair"
@@ -129,7 +130,8 @@ def lakeShortOption : (opt : Char) → CliM PUnit
 
 def lakeLongOption : (opt : String) → CliM PUnit
 | "--help"    => modifyThe LakeOptions ({· with wantsHelp := true})
-| "--verbose" => modifyThe LakeOptions ({· with verbose := true})
+| "--quiet"   => modifyThe LakeOptions ({· with verbosity := .quiet})
+| "--verbose" => modifyThe LakeOptions ({· with verbosity := .verbose})
 | "--dir"     => do let rootDir ← takeOptArg "--dir" "path"; modifyThe LakeOptions ({· with rootDir})
 | "--file"    => do let configFile ← takeOptArg "--file" "path"; modifyThe LakeOptions ({· with configFile})
 | "--lean"    => do setLean <| ← takeOptArg "--lean" "path or command"
@@ -179,9 +181,9 @@ def printPaths (config : LoadConfig) (imports : List String := []) : MainM PUnit
     if (← IO.getEnv invalidConfigEnvVar) matches some .. then
       IO.eprintln s!"Error parsing '{configFile}'.  Please restart the lean server after fixing the Lake configuration file."
       exit 1
-    let ws ← loadWorkspace config |>.run config.verbose
+    let ws ← loadWorkspace config |>.run config.verbosity
     let ctx ← mkBuildContext ws
-    let dynlibs ← ws.root.buildImportsAndDeps imports |>.run (MonadLog.eio ws.verbose) ctx
+    let dynlibs ← ws.root.buildImportsAndDeps imports |>.run (MonadLog.eio ws.verbosity) ctx
     IO.println <| Json.compress <| toJson {ws.leanPaths with loadDynlibPaths := dynlibs}
   else
     exit noConfigFileCode
@@ -208,7 +210,7 @@ def exe (name : Name) (args  : Array String := #[]) : LakeT IO UInt32 := do
   let ws ← getWorkspace
   if let some exe := ws.findLeanExe? name then
     let ctx ← mkBuildContext ws
-    let exeFile ← (exe.build >>= (·.await)).run (MonadLog.eio ws.verbose) ctx
+    let exeFile ← (exe.build >>= (·.await)).run (MonadLog.eio ws.verbosity) ctx
     env exeFile.toString args
   else
     error s!"unknown executable `{name}`"
@@ -239,7 +241,7 @@ protected def list : CliM PUnit := do
   processOptions lakeOption
   let config ← mkLoadConfig (← getThe LakeOptions)
   noArgsRem do
-    let ws ← loadWorkspace config |>.run config.verbose
+    let ws ← loadWorkspace config |>.run config.verbosity
     ws.packageMap.forM fun _ pkg => do
       let pkgName := pkg.name.toString (escape := false)
       pkg.scripts.forM fun name _ =>
@@ -250,7 +252,7 @@ protected nonrec def run : CliM PUnit := do
   processOptions lakeOption
   let spec ← takeArg "script name"; let args ← takeArgs
   let config ← mkLoadConfig (← getThe LakeOptions)
-  let ws ← loadWorkspace config |>.run config.verbose
+  let ws ← loadWorkspace config |>.run config.verbosity
   let (pkg, scriptName) ← parseScriptSpec ws spec
   if let some script := pkg.scripts.find? scriptName then
     exit <| ← script.run args |>.run {
@@ -264,7 +266,7 @@ protected def doc : CliM PUnit := do
   let spec ← takeArg "script name"
   let config ← mkLoadConfig (← getThe LakeOptions)
   noArgsRem do
-    let ws ← loadWorkspace config |>.run config.verbose
+    let ws ← loadWorkspace config |>.run config.verbosity
     let (pkg, scriptName) ← parseScriptSpec ws spec
     if let some script := pkg.scripts.find? scriptName then
       match script.doc? with
@@ -291,28 +293,28 @@ protected def new : CliM PUnit := do
   processOptions lakeOption
   let pkgName ← takeArg "package name"
   let template ← parseTemplateSpec <| (← takeArg?).getD ""
-  noArgsRem <| new pkgName template |>.run (← getThe LakeOptions).verbose
+  noArgsRem <| new pkgName template |>.run (← getThe LakeOptions).verbosity
 
 protected def init : CliM PUnit := do
   processOptions lakeOption
   let pkgName ← takeArg "package name"
   let template ← parseTemplateSpec <| (← takeArg?).getD ""
-  noArgsRem <| init pkgName template |>.run (← getThe LakeOptions).verbose
+  noArgsRem <| init pkgName template |>.run (← getThe LakeOptions).verbosity
 
 protected def build : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
-  let ws ← loadWorkspace config |>.run config.verbose
+  let ws ← loadWorkspace config |>.run config.verbosity
   let targetSpecs ← takeArgs
   let specs ← parseTargetSpecs ws targetSpecs
   let ctx ← mkBuildContext ws
-  BuildM.run (MonadLog.io ws.verbose) ctx <| buildSpecs specs
+  BuildM.run (MonadLog.io ws.verbosity) ctx <| buildSpecs specs
 
 protected def update : CliM PUnit := do
   processOptions lakeOption
   let config ← mkLoadConfig (← getThe LakeOptions) (updateDeps := true)
-  noArgsRem <| discard <| loadWorkspace config |>.run config.verbose
+  noArgsRem <| discard <| loadWorkspace config |>.run config.verbosity
 
 protected def printPaths : CliM PUnit := do
   processOptions lakeOption
@@ -322,7 +324,7 @@ protected def printPaths : CliM PUnit := do
 protected def clean : CliM PUnit := do
   processOptions lakeOption
   let config ← mkLoadConfig (← getThe LakeOptions)
-  noArgsRem (← loadWorkspace config |>.run config.verbose).root.clean
+  noArgsRem (← loadWorkspace config |>.run config.verbosity).root.clean
 
 protected def script : CliM PUnit := do
   if let some cmd ← takeArg? then
@@ -339,19 +341,19 @@ protected def serve : CliM PUnit := do
   let opts ← getThe LakeOptions
   let args := opts.subArgs.toArray
   let config ← mkLoadConfig opts
-  noArgsRem do exit <| ← serve config args |>.run config.verbose
+  noArgsRem do exit <| ← serve config args |>.run config.verbosity
 
 protected def env : CliM PUnit := do
   let cmd ← takeArg "command"; let args ← takeArgs
   let config ← mkLoadConfig (← getThe LakeOptions)
-  let ws ← loadWorkspace config |>.run config.verbose
+  let ws ← loadWorkspace config |>.run config.verbosity
   let ctx := mkLakeContext ws
   exit <| ← (env cmd args.toArray).run ctx
 
 protected def exe : CliM PUnit := do
   let exeName ← takeArg "executable name"; let args ← takeArgs
   let config ← mkLoadConfig (← getThe LakeOptions)
-  let ws ← loadWorkspace config |>.run config.verbose
+  let ws ← loadWorkspace config |>.run config.verbosity
   let ctx := mkLakeContext ws
   exit <| ← (exe exeName args.toArray).run ctx
 

--- a/Lake/Config/Workspace.lean
+++ b/Lake/Config/Workspace.lean
@@ -30,6 +30,8 @@ structure Workspace : Type where
   packageFacetConfigs : DNameMap PackageFacetConfig
   /-- Name-configuration map of library facets defined in the workspace. -/
   libraryFacetConfigs : DNameMap LibraryFacetConfig
+  /-- True if Lake should print additional information while building this workspace. -/
+  verbose : Bool := false
   deriving Inhabited
 
 hydrate_opaque_type OpaqueWorkspace Workspace

--- a/Lake/Config/Workspace.lean
+++ b/Lake/Config/Workspace.lean
@@ -31,8 +31,6 @@ structure Workspace : Type where
   packageFacetConfigs : DNameMap PackageFacetConfig
   /-- Name-configuration map of library facets defined in the workspace. -/
   libraryFacetConfigs : DNameMap LibraryFacetConfig
-  /-- The verbosity setting for logging messages. -/
-  verbosity : Verbosity := .normal
   deriving Inhabited
 
 hydrate_opaque_type OpaqueWorkspace Workspace

--- a/Lake/Config/Workspace.lean
+++ b/Lake/Config/Workspace.lean
@@ -7,6 +7,7 @@ import Lean.Util.Paths
 import Lake.Config.FacetConfig
 import Lake.Config.TargetConfig
 import Lake.Config.Env
+import Lake.Util.Log
 
 open System
 open Lean (LeanPaths)
@@ -30,8 +31,8 @@ structure Workspace : Type where
   packageFacetConfigs : DNameMap PackageFacetConfig
   /-- Name-configuration map of library facets defined in the workspace. -/
   libraryFacetConfigs : DNameMap LibraryFacetConfig
-  /-- True if Lake should print additional information while building this workspace. -/
-  verbose : Bool := false
+  /-- The verbosity setting for logging messages. -/
+  verbosity : Verbosity := .normal
   deriving Inhabited
 
 hydrate_opaque_type OpaqueWorkspace Workspace

--- a/Lake/Load/Config.lean
+++ b/Lake/Load/Config.lean
@@ -25,6 +25,8 @@ structure LoadConfig where
   configOpts : NameMap String := {}
   /-- The Lean options with which to elaborate the configuration file. -/
   leanOpts : Options := {}
+  /-- True if Lake should print additional information about executed commands. -/
+  verbose : Bool := false
   /--
   Whether to update dependencies during resolution
   or fallback to the ones listed in the manifest.

--- a/Lake/Load/Config.lean
+++ b/Lake/Load/Config.lean
@@ -6,6 +6,7 @@ Authors: Mac Malone
 import Lean.Data.Name
 import Lean.Data.Options
 import Lake.Config.Env
+import Lake.Util.Log
 
 namespace Lake
 open System Lean
@@ -25,8 +26,8 @@ structure LoadConfig where
   configOpts : NameMap String := {}
   /-- The Lean options with which to elaborate the configuration file. -/
   leanOpts : Options := {}
-  /-- True if Lake should print additional information about executed commands. -/
-  verbose : Bool := false
+  /-- The verbosity setting for logging messages. -/
+  verbosity : Verbosity := .normal
   /--
   Whether to update dependencies during resolution
   or fallback to the ones listed in the manifest.

--- a/Lake/Load/Main.lean
+++ b/Lake/Load/Main.lean
@@ -73,7 +73,7 @@ def loadWorkspace (config : LoadConfig) : LogIO Workspace := do
   Lean.searchPathRef.set config.env.leanSearchPath
   let root ← loadPkg config.rootDir config.configOpts config.leanOpts config.configFile
   let ws : Workspace := {
-    root, lakeEnv := config.env, verbose := config.verbose
+    root, lakeEnv := config.env, verbosity := config.verbosity
     moduleFacetConfigs := initModuleFacetConfigs
     packageFacetConfigs := initPackageFacetConfigs
     libraryFacetConfigs := initLibraryFacetConfigs

--- a/Lake/Load/Main.lean
+++ b/Lake/Load/Main.lean
@@ -73,7 +73,7 @@ def loadWorkspace (config : LoadConfig) : LogIO Workspace := do
   Lean.searchPathRef.set config.env.leanSearchPath
   let root ← loadPkg config.rootDir config.configOpts config.leanOpts config.configFile
   let ws : Workspace := {
-    root, lakeEnv := config.env, verbosity := config.verbosity
+    root, lakeEnv := config.env
     moduleFacetConfigs := initModuleFacetConfigs
     packageFacetConfigs := initPackageFacetConfigs
     libraryFacetConfigs := initLibraryFacetConfigs

--- a/Lake/Load/Main.lean
+++ b/Lake/Load/Main.lean
@@ -73,7 +73,7 @@ def loadWorkspace (config : LoadConfig) : LogIO Workspace := do
   Lean.searchPathRef.set config.env.leanSearchPath
   let root ← loadPkg config.rootDir config.configOpts config.leanOpts config.configFile
   let ws : Workspace := {
-    root, lakeEnv := config.env
+    root, lakeEnv := config.env, verbose := config.verbose
     moduleFacetConfigs := initModuleFacetConfigs
     packageFacetConfigs := initPackageFacetConfigs
     libraryFacetConfigs := initLibraryFacetConfigs

--- a/Lake/Util/Log.lean
+++ b/Lake/Util/Log.lean
@@ -15,9 +15,13 @@ inductive LogLevel
 /-! # Class -/
 
 class MonadLog (m : Type u → Type v) where
+  verbose : m (ULift Bool)
   log (message : String) (level : LogLevel) : m PUnit
 
 export MonadLog (log)
+
+abbrev logVerbose [Monad m] [MonadLog m] (message : String) : m PUnit := do
+  if (← MonadLog.verbose (m := m)).1 then log message .info
 
 abbrev logInfo [MonadLog m] (message : String) : m PUnit :=
   log message .info
@@ -31,26 +35,29 @@ abbrev logError  [MonadLog m] (message : String) : m PUnit :=
 namespace MonadLog
 
 def nop [Pure m] : MonadLog m :=
-  ⟨fun _ _ => pure ()⟩
+  ⟨pure ⟨false⟩, fun _ _ => pure ()⟩
 
 instance [Pure m] : Inhabited (MonadLog m) := ⟨MonadLog.nop⟩
 
-def io [MonadLiftT BaseIO m] : MonadLog m where
+def io [MonadLiftT BaseIO m] (verbose := false) : MonadLog m where
+  verbose := (pure ⟨verbose⟩ : BaseIO _)
   log msg
     | .info => IO.println msg.trim |>.catchExceptions fun _ => pure ()
     | .warning => IO.eprintln s!"warning: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .error => IO.eprintln s!"error: {msg.trim}" |>.catchExceptions fun _ => pure ()
 
-def eio [MonadLiftT BaseIO m] : MonadLog m where
+def eio [MonadLiftT BaseIO m] (verbose := false) : MonadLog m where
+  verbose := (pure ⟨verbose⟩ : BaseIO _)
   log msg
-    | .info => IO.eprintln s!"info: {msg.trim}"  |>.catchExceptions fun _ => pure ()
+    | .info => IO.eprintln s!"info: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .warning => IO.eprintln s!"warning: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .error => IO.eprintln s!"error: {msg.trim}" |>.catchExceptions fun _ => pure ()
 
 def lift [MonadLiftT m n] (self : MonadLog m) : MonadLog n where
+  verbose := liftM <| self.verbose
   log msg lv := liftM <| self.log msg lv
 
-instance [MonadLift m n] [methods : MonadLog m] : MonadLog n  := lift methods
+instance [MonadLift m n] [methods : MonadLog m] : MonadLog n := lift methods
 
 /-- Log the given error message and then fail. -/
 protected def error [Alternative m] [MonadLog m] (msg : String) : m α :=
@@ -67,6 +74,7 @@ instance [Pure n] [Inhabited α] : Inhabited (MonadLogT m n α) :=
   ⟨fun _ => pure Inhabited.default⟩
 
 instance [Monad n] [MonadLiftT m n] : MonadLog (MonadLogT m n) where
+  verbose := do (← read).verbose
   log msg lv := do (← read).log msg lv
 
 namespace MonadLogT

--- a/Lake/Util/Log.lean
+++ b/Lake/Util/Log.lean
@@ -12,16 +12,27 @@ inductive LogLevel
 | warning
 | error
 
+inductive Verbosity
+| quiet
+| normal
+| verbose
+deriving BEq
+
+instance : Inhabited Verbosity := ⟨.normal⟩
+
 /-! # Class -/
 
 class MonadLog (m : Type u → Type v) where
-  verbose : m (ULift Bool)
+  verbosity : m (ULift Verbosity)
   log (message : String) (level : LogLevel) : m PUnit
 
 export MonadLog (log)
 
 abbrev logVerbose [Monad m] [MonadLog m] (message : String) : m PUnit := do
-  if (← MonadLog.verbose (m := m)).1 then log message .info
+  if (← MonadLog.verbosity (m := m)).1 == .verbose then log message .info
+
+abbrev logAuxInfo [Monad m] [MonadLog m] (message : String) : m PUnit := do
+  if (← MonadLog.verbosity (m := m)).1 != .quiet then log message .info
 
 abbrev logInfo [MonadLog m] (message : String) : m PUnit :=
   log message .info
@@ -35,26 +46,26 @@ abbrev logError  [MonadLog m] (message : String) : m PUnit :=
 namespace MonadLog
 
 def nop [Pure m] : MonadLog m :=
-  ⟨pure ⟨false⟩, fun _ _ => pure ()⟩
+  ⟨pure ⟨.normal⟩, fun _ _ => pure ()⟩
 
 instance [Pure m] : Inhabited (MonadLog m) := ⟨MonadLog.nop⟩
 
-def io [MonadLiftT BaseIO m] (verbose := false) : MonadLog m where
-  verbose := (pure ⟨verbose⟩ : BaseIO _)
+def io [MonadLiftT BaseIO m] (verbosity := Verbosity.normal) : MonadLog m where
+  verbosity := (pure ⟨verbosity⟩ : BaseIO _)
   log msg
     | .info => IO.println msg.trim |>.catchExceptions fun _ => pure ()
     | .warning => IO.eprintln s!"warning: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .error => IO.eprintln s!"error: {msg.trim}" |>.catchExceptions fun _ => pure ()
 
-def eio [MonadLiftT BaseIO m] (verbose := false) : MonadLog m where
-  verbose := (pure ⟨verbose⟩ : BaseIO _)
+def eio [MonadLiftT BaseIO m] (verbosity := Verbosity.normal) : MonadLog m where
+  verbosity := (pure ⟨verbosity⟩ : BaseIO _)
   log msg
     | .info => IO.eprintln s!"info: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .warning => IO.eprintln s!"warning: {msg.trim}" |>.catchExceptions fun _ => pure ()
     | .error => IO.eprintln s!"error: {msg.trim}" |>.catchExceptions fun _ => pure ()
 
 def lift [MonadLiftT m n] (self : MonadLog m) : MonadLog n where
-  verbose := liftM <| self.verbose
+  verbosity := liftM <| self.verbosity
   log msg lv := liftM <| self.log msg lv
 
 instance [MonadLift m n] [methods : MonadLog m] : MonadLog n := lift methods
@@ -74,7 +85,7 @@ instance [Pure n] [Inhabited α] : Inhabited (MonadLogT m n α) :=
   ⟨fun _ => pure Inhabited.default⟩
 
 instance [Monad n] [MonadLiftT m n] : MonadLog (MonadLogT m n) where
-  verbose := do (← read).verbose
+  verbosity := do (← read).verbosity
   log msg lv := do (← read).log msg lv
 
 namespace MonadLogT

--- a/Lake/Util/MainM.lean
+++ b/Lake/Util/MainM.lean
@@ -76,7 +76,7 @@ instance : MonadError MainM := ⟨MainM.error⟩
 instance [ToString ε] : MonadLift (EIO ε) MainM := ⟨MonadError.runEIO⟩
 instance : MonadLift IO MainM := inferInstance -- necessary, but don't know why
 
-def _root_.Lake.LogIO.run (x : LogIO α) (verbosity := Verbosity.normal) : MainM α :=
+def runLogIO (x : LogIO α) (verbosity := Verbosity.normal) : MainM α :=
   liftM <| MonadLogT.run (MonadLog.eio verbosity) x
 
-instance : MonadLift LogIO MainM := ⟨LogIO.run⟩
+instance : MonadLift LogIO MainM := ⟨runLogIO⟩

--- a/Lake/Util/MainM.lean
+++ b/Lake/Util/MainM.lean
@@ -76,7 +76,7 @@ instance : MonadError MainM := ⟨MainM.error⟩
 instance [ToString ε] : MonadLift (EIO ε) MainM := ⟨MonadError.runEIO⟩
 instance : MonadLift IO MainM := inferInstance -- necessary, but don't know why
 
-def _root_.Lake.LogIO.run (x : LogIO α) (verbose := false) : MainM α :=
-  liftM <| MonadLogT.run (MonadLog.eio verbose) x
+def _root_.Lake.LogIO.run (x : LogIO α) (verbosity := Verbosity.normal) : MainM α :=
+  liftM <| MonadLogT.run (MonadLog.eio verbosity) x
 
 instance : MonadLift LogIO MainM := ⟨LogIO.run⟩

--- a/Lake/Util/MainM.lean
+++ b/Lake/Util/MainM.lean
@@ -75,4 +75,8 @@ protected def error (msg : String) (rc : ExitCode := 1) : MainM α := do
 instance : MonadError MainM := ⟨MainM.error⟩
 instance [ToString ε] : MonadLift (EIO ε) MainM := ⟨MonadError.runEIO⟩
 instance : MonadLift IO MainM := inferInstance -- necessary, but don't know why
-instance : MonadLift LogIO MainM := ⟨fun x => liftM <| x.run MonadLog.eio⟩
+
+def _root_.Lake.LogIO.run (x : LogIO α) (verbose := false) : MainM α :=
+  liftM <| MonadLogT.run (MonadLog.eio verbose) x
+
+instance : MonadLift LogIO MainM := ⟨LogIO.run⟩

--- a/examples/ffi/lib/lakefile.lean
+++ b/examples/ffi/lib/lakefile.lean
@@ -20,8 +20,8 @@ def ffiOTarget : FileTarget :=
   let oFile := cBuildDir / "ffi.o"
   let srcTarget := inputFileTarget <| cSrcDir / "ffi.cpp"
   fileTargetWithDep oFile srcTarget fun srcFile => do
-    compileO oFile srcFile #["-I", (← getLeanIncludeDir).toString, "-fPIC"] "c++"
+    compileO `ffi oFile srcFile #["-I", (← getLeanIncludeDir).toString, "-fPIC"] "c++"
 
 extern_lib cLib :=
   let libFile := cBuildDir / nameToStaticLib "leanffi"
-  staticLibTarget libFile #[ffiOTarget]
+  staticLibTarget `leanffi libFile #[ffiOTarget]

--- a/test/50/test.sh
+++ b/test/50/test.sh
@@ -5,7 +5,7 @@ LAKE=${LAKE:-../../../build/bin/lake}
 
 cd foo
 rm -rf build
-${LAKE} build -KleanArgs=-Dhygiene=true -K leancArgs=-DBAR | grep -m2 foo.c
-${LAKE} build -KleanArgs=-Dhygiene=false -K leancArgs=-DBAZ | grep -m2 foo.c
-${LAKE} build -KleanArgs=-Dhygiene=false -K leancArgs=-DBAR | grep -m1 foo.o
-${LAKE} build -KleanArgs=-Dhygiene=true -K leancArgs=-DBAR | grep -m1 foo.olean
+${LAKE} build -v -KleanArgs=-Dhygiene=true -K leancArgs=-DBAR | grep -m2 foo.c
+${LAKE} build -v -KleanArgs=-Dhygiene=false -K leancArgs=-DBAZ | grep -m2 foo.c
+${LAKE} build -v -KleanArgs=-Dhygiene=false -K leancArgs=-DBAR | grep -m1 foo.o
+${LAKE} build -v -KleanArgs=-Dhygiene=true -K leancArgs=-DBAR | grep -m1 foo.olean

--- a/test/62/test.sh
+++ b/test/62/test.sh
@@ -9,4 +9,4 @@ lake +leanprover/lean4:nightly-2022-06-30 new foo
 cd foo
 lake +leanprover/lean4:nightly-2022-06-30 build | grep -m1 foo
 cp ../../../lean-toolchain lean-toolchain
-${LAKE:-../../../build/bin/lake} build | grep -m1 foo
+${LAKE:-../../../build/bin/lake} build -v | grep -m1 foo

--- a/test/84/test.sh
+++ b/test/84/test.sh
@@ -19,7 +19,7 @@ pushd b
 cat >>lakefile.lean <<EOF
 require a from git "../a" @ "master"
 EOF
-$LAKE1 update -v
+$LAKE1 update
 git add .
 git config user.name test
 git config user.email test@example.com

--- a/test/84/test.sh
+++ b/test/84/test.sh
@@ -32,6 +32,6 @@ git commit -am 'second commit in a'
 popd
 
 pushd b
-$LAKE1 update
+$LAKE1 update -v
 git diff | grep -m1 manifest
 popd

--- a/test/84/test.sh
+++ b/test/84/test.sh
@@ -19,7 +19,7 @@ pushd b
 cat >>lakefile.lean <<EOF
 require a from git "../a" @ "master"
 EOF
-$LAKE1 update
+$LAKE1 update -v
 git add .
 git config user.name test
 git config user.email test@example.com


### PR DESCRIPTION
`lake build` will no longer print the commands it is executing, resulting in significantly less output and a higher signal/noise ratio. The old behavior can be recovered through the `lake build -v` or `lake build --verbose` option.

One drawback of this is that the user no longer gets file progress information. A cleaned up status report (possibly using ncurses-style overwriting for supported consoles) similar to lean 3 is future work.