### PR TITLE
chore: bump for lean4#1384

### DIFF
--- a/Lake/DSL/Attributes.lean
+++ b/Lake/DSL/Attributes.lean
@@ -9,28 +9,28 @@ open Lean
 namespace Lake
 
 initialize packageAttr : TagAttribute ←
-  registerTagAttribute `package "mark a definition as a Lake package configuration"
+  registerTagAttribute decl_name% `package "mark a definition as a Lake package configuration"
 
 initialize packageDepAttr : TagAttribute ←
-  registerTagAttribute `packageDep "mark a definition as a Lake package dependency"
+  registerTagAttribute decl_name% `packageDep "mark a definition as a Lake package dependency"
 
 initialize scriptAttr : TagAttribute ←
-  registerTagAttribute `script "mark a definition as a Lake script"
+  registerTagAttribute decl_name% `script "mark a definition as a Lake script"
 
 initialize leanLibAttr : TagAttribute ←
-  registerTagAttribute `leanLib "mark a definition as a Lake Lean library target configuration"
+  registerTagAttribute decl_name% `leanLib "mark a definition as a Lake Lean library target configuration"
 
 initialize leanExeAttr : TagAttribute ←
-  registerTagAttribute `leanExe "mark a definition as a Lake Lean executable target configuration"
+  registerTagAttribute decl_name% `leanExe "mark a definition as a Lake Lean executable target configuration"
 
 initialize externLibAttr : TagAttribute ←
-  registerTagAttribute `externLib "mark a definition as a Lake external library target"
+  registerTagAttribute decl_name% `externLib "mark a definition as a Lake external library target"
 
 initialize targetAttr : TagAttribute ←
-  registerTagAttribute `target "mark a definition as a custom Lake target"
+  registerTagAttribute decl_name% `target "mark a definition as a custom Lake target"
 
 initialize defaultTargetAttr : TagAttribute ←
-  registerTagAttribute `defaultTarget "mark a Lake target as the package's default"
+  registerTagAttribute decl_name% `defaultTarget "mark a Lake target as the package's default"
     fun name => do
       let valid ← getEnv <&> fun env =>
         leanLibAttr.hasTag env name ||
@@ -41,7 +41,7 @@ initialize defaultTargetAttr : TagAttribute ←
         throwError "attribute `defaultTarget` can only be used on a target (e.g., `lean_lib`, `lean_exe`)"
 
 initialize moduleFacetAttr : TagAttribute ←
-  registerTagAttribute `moduleFacet "mark a definition as a Lake module facet"
+  registerTagAttribute decl_name% `moduleFacet "mark a definition as a Lake module facet"
 
 initialize packageFacetAttr : TagAttribute ←
-  registerTagAttribute `packageFacet "mark a definition as a Lake package facet"
+  registerTagAttribute decl_name% `packageFacet "mark a definition as a Lake package facet"


### PR DESCRIPTION
This adds support for leanprover/lean4#1384 . Because of the submodule situation I think leanprover/lean4#1384 can't compile until it can see this commit, so if someone could create a branch for this commit upstream that would be helpful.