### PR TITLE
fix: also update when inputRev changes

### DIFF
--- a/Lake/CLI/Actions.lean
+++ b/Lake/CLI/Actions.lean
@@ -26,15 +26,16 @@ If no configuration file exists, exit silently with `noConfigFileCode` (i.e, 2).
 
 The `print-paths` command is used internally by Lean 4 server.
 -/
-def printPaths (config : LoadConfig) (imports : List String := []) (oldMode : Bool := false) : MainM PUnit := do
+def printPaths (config : LoadConfig) (imports : List String := [])
+(oldMode : Bool := false) (verbosity : Verbosity := .normal) : MainM PUnit := do
   let configFile := config.rootDir / config.configFile
   if (← configFile.pathExists) then
     if (← IO.getEnv invalidConfigEnvVar) matches some .. then
       IO.eprintln s!"Error parsing '{configFile}'.  Please restart the lean server after fixing the Lake configuration file."
       exit 1
-    let ws ← MainM.runLogIO (loadWorkspace config) config.verbosity
+    let ws ← MainM.runLogIO (loadWorkspace config) verbosity
     let dynlibs ← ws.runBuild (buildImportsAndDeps imports) oldMode
-      |>.run (MonadLog.eio config.verbosity)
+      |>.run (MonadLog.eio verbosity)
     IO.println <| Json.compress <| toJson {
       oleanPath := ws.leanPath
       srcPath := ws.leanSrcPath

--- a/Lake/CLI/Init.lean
+++ b/Lake/CLI/Init.lean
@@ -22,7 +22,6 @@ def toolchainFileName : FilePath :=
 def gitignoreContents :=
 s!"/{defaultBuildDir}
 /{defaultPackagesDir}/*
-!/{defaultPackagesDir}/{defaultManifestFileName}
 "
 
 def libFileContents :=

--- a/Lake/CLI/Main.lean
+++ b/Lake/CLI/Main.lean
@@ -63,7 +63,6 @@ def LakeOptions.mkLoadConfig
     configFile := opts.rootDir / opts.configFile
     configOpts := opts.configOpts
     leanOpts := Lean.Options.empty
-    verbosity := opts.verbosity
     updateDeps
   }
 
@@ -261,7 +260,7 @@ protected def build : CliM PUnit := do
   let ws ← loadWorkspace config
   let targetSpecs ← takeArgs
   let specs ← parseTargetSpecs ws targetSpecs
-  ws.runBuild (buildSpecs specs) opts.oldMode |>.run (MonadLog.io config.verbosity)
+  ws.runBuild (buildSpecs specs) opts.oldMode |>.run (MonadLog.io opts.verbosity)
 
 protected def resolveDeps : CliM PUnit := do
   processOptions lakeOption
@@ -290,7 +289,7 @@ protected def printPaths : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
-  printPaths config (← takeArgs) opts.oldMode
+  printPaths config (← takeArgs) opts.oldMode opts.verbosity
 
 protected def clean : CliM PUnit := do
   processOptions lakeOption

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -42,8 +42,8 @@ def nameToArchive (name? : Option String) : String :=
 /-! # Defaults -/
 --------------------------------------------------------------------------------
 
-/-- The default name of the package manifest. -/
-def defaultManifestFileName := "manifest.json"
+/-- The default setting for a `PackageConfig`'s `manifestFile` option. -/
+def defaultManifestFile := "lake-manifest.json"
 
 /-- The default setting for a `PackageConfig`'s `buildDir` option. -/
 def defaultBuildDir : FilePath := "build"
@@ -74,9 +74,9 @@ structure PackageConfig extends WorkspaceConfig, LeanConfig where
   The path of a package's manifest file, which stores the exact versions
   of its resolved dependencies.
 
-  Defaults to `packagesDir` / `defaultManifestFileName` (i.e., `manifest.json`).
+  Defaults to `defaultManifestFile` (i.e., `lake-manifest.json`).
   -/
-  manifestFile := packagesDir / defaultManifestFileName
+  manifestFile := defaultManifestFile
 
   /-- An `Array` of target names to build whenever the package is used. -/
   extraDepTargets : Array Name := #[]

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -206,8 +206,6 @@ structure Package where
   scripts : NameMap Script := {}
   deriving Inhabited
 
-#check String.dropRight
-
 hydrate_opaque_type OpaquePackage Package
 
 abbrev PackageSet := RBTree Package (·.config.name.quickCmp ·.config.name)

--- a/Lake/Load/Config.lean
+++ b/Lake/Load/Config.lean
@@ -26,8 +26,6 @@ structure LoadConfig where
   configOpts : NameMap String := {}
   /-- The Lean options with which to elaborate the configuration file. -/
   leanOpts : Options := {}
-  /-- The verbosity setting for logging messages. -/
-  verbosity : Verbosity := .normal
   /--
   Whether to update dependencies during resolution
   or fallback to the ones listed in the manifest.

--- a/Lake/Load/Main.lean
+++ b/Lake/Load/Main.lean
@@ -49,12 +49,7 @@ def resolveDep (packagesDir : FilePath) (pkg : Package) (dep : Dependency)
   let depManifest ← Manifest.loadOrEmpty depPkg.manifestFile
   for depEntry in depManifest do
     if let some entry := (← get).find? depEntry.name then
-      let shouldUpdate :=
-        match entry.inputRev?, depEntry.inputRev? with
-        | none,     none     => entry.rev != depEntry.rev
-        | none,     some _   => false
-        | some _,   none     => false
-        | some rev, some dep => rev = dep ∧ entry.rev ≠ depEntry.rev
+      let shouldUpdate := entry.rev ≠ depEntry.rev
       let contributors := entry.contributors.insert depPkg.name depEntry.toPersistentPackageEntry
       modify (·.insert {entry with contributors, shouldUpdate})
     else

--- a/Lake/Util/DRBMap.lean
+++ b/Lake/Util/DRBMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mac Malone
 -/
-import Std.Data.RBMap
+import Bootstrap.Data.RBMap
 import Lake.Util.Compare
 
 namespace Lake

--- a/Lake/Version.lean
+++ b/Lake/Version.lean
@@ -7,10 +7,10 @@ Authors: Mac Malone
 namespace Lake
 
 def version.major := 4
-def version.minor := 0
+def version.minor := 1
 def version.patch := 0
 
-def version.isPrerelease := false
+def version.isPrerelease := true
 def version.isRelease := !isPrerelease
 def version.specialDesc := if isPrerelease then "pre" else ""
 

--- a/examples/ffi/package.sh
+++ b/examples/ffi/package.sh
@@ -1,10 +1,10 @@
 set -ex
 
 cd app
-${LAKE:-../../../build/bin/lake} build
+${LAKE:-../../../build/bin/lake} build -v
 cd ..
 
 
 cd lib
-${LAKE:-../../../build/bin/lake} build
+${LAKE:-../../../build/bin/lake} build -v
 cd ..

--- a/examples/ffi/test.sh
+++ b/examples/ffi/test.sh
@@ -5,4 +5,4 @@ set -e
 ./app/build/bin/app
 ./lib/build/bin/test
 
-${LAKE:-../../build/bin/lake} -d app build Test
+${LAKE:-../../build/bin/lake} -d app build -v Test

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-08-08
+leanprover/lean4:nightly-2022-08-31

--- a/test/104/clean.sh
+++ b/test/104/clean.sh
@@ -1,2 +1,3 @@
 rm -rf test/build
 rm -rf test/lean_packages
+rm -f lake-manifest.json

--- a/test/104/test.sh
+++ b/test/104/test.sh
@@ -4,17 +4,18 @@ set -exo pipefail
 LAKE=${LAKE:-../../../build/bin/lake}
 
 TEST_URL=https://example.com/hello.git
+MANIFEST=lake-manifest.json
 
 ./clean.sh
 
 cd test
 $LAKE build
-cat lean_packages/manifest.json
+cat $MANIFEST
 if [ "`uname`" = Darwin ]; then
-  sed -i '' "s,\\.\\.[^\"]*,$TEST_URL," lean_packages/manifest.json
+  sed -i '' "s,\\.\\.[^\"]*,$TEST_URL," $MANIFEST
 else
-  sed -i "s,\\.\\.[^\"]*,$TEST_URL," lean_packages/manifest.json
+  sed -i "s,\\.\\.[^\"]*,$TEST_URL," $MANIFEST
 fi
-cat lean_packages/manifest.json
+cat $MANIFEST
 git -C lean_packages/hello remote set-url origin $TEST_URL
 $LAKE build -K url=$TEST_URL

--- a/test/104/test/.gitignore
+++ b/test/104/test/.gitignore
@@ -1,2 +1,3 @@
 /build
 /lean_packages
+lake-manifest.json

--- a/test/manifest/test.sh
+++ b/test/manifest/test.sh
@@ -93,7 +93,7 @@ popd
 
 # issue 119
 pushd b
-sed_i "s/master/$(env --chdir=../a git rev-parse HEAD)/" lakefile.lean
+sed_i "s/master/$(git -C ../a rev-parse HEAD)/" lakefile.lean
 $LAKE update -v
 git commit -am 'third commit in b'
 popd

--- a/test/manifest/test.sh
+++ b/test/manifest/test.sh
@@ -15,6 +15,7 @@ fi
 # https://github.com/leanprover/lake/issues/70
 # https://github.com/leanprover/lake/issues/84
 # https://github.com/leanprover/lake/issues/85
+# https://github.com/leanprover/lake/issues/119
 
 $LAKE new a lib
 pushd a
@@ -76,4 +77,29 @@ git diff | grep -m1 manifest
 sed_i 's/master/init/g' lakefile.lean
 $LAKE resolve-deps -v 2>&1 | grep -m1 'listed in manifest does not match `init`'
 git reset --hard
+popd
+
+pushd a
+echo '-- third commit in a' >>A.lean
+git commit -am 'third commit in a'
+popd
+
+# issue 70
+pushd d
+$LAKE update -v
+if grep 'third commit in a' lean_packages/a/A.lean; then false; fi
+git diff --exit-code
+popd
+
+# issue 119
+pushd b
+sed_i "s/master/$(env --chdir=../a git rev-parse HEAD)/" lakefile.lean
+$LAKE update -v
+git commit -am 'third commit in b'
+popd
+pushd d
+sed_i '/require c/d' lakefile.lean
+$LAKE update -v
+grep 'third commit in a' lean_packages/a/A.lean
+git commit -am 'second commit in d'
 popd

--- a/test/manifest/test.sh
+++ b/test/manifest/test.sh
@@ -92,10 +92,17 @@ git diff --exit-code
 popd
 
 # issue 119
+pushd a
+git checkout -b main
+popd
 pushd b
-sed_i "s/master/$(git -C ../a rev-parse HEAD)/" lakefile.lean
+sed_i 's/master/main/' lakefile.lean
 $LAKE update -v
 git commit -am 'third commit in b'
+popd
+pushd a
+sed_i 's/third commit/fourth commit/' A.lean
+git commit -am 'fourth commit in a'
 popd
 pushd d
 sed_i '/require c/d' lakefile.lean


### PR DESCRIPTION
It turns out that #119 already worked in some cases.  Namely `lake update` would pick up changes in transitive dependencies, but only if the `inputRev` stayed the same.  If the direct dependency switched to another branch of the transitive dependency, then `lake update` would not pick up the new revision.

This PR removes the `inputRev` check and adds a test for this issue.

Fixes #119.