### PR TITLE
fix: do not compute transitive imports for every module

### DIFF
--- a/Lake/Build/Common.lean
+++ b/Lake/Build/Common.lean
@@ -54,6 +54,12 @@ namespace Lake
 
 /-! # Common Builds -/
 
+def buildO (name : String)
+(oFile : FilePath) (srcJob : BuildJob FilePath)
+(args : Array String := #[]) (compiler : FilePath := "cc") : SchedulerM (BuildJob FilePath) :=
+  buildFileAfterDep oFile srcJob (extraDepTrace := computeHash args) fun srcFile => do
+     compileO name oFile srcFile args compiler
+
 def buildLeanO (name : String)
 (oFile : FilePath) (srcJob : BuildJob FilePath)
 (args : Array String := #[]) : SchedulerM (BuildJob FilePath) :=

--- a/Lake/Build/Common.lean
+++ b/Lake/Build/Common.lean
@@ -115,3 +115,14 @@ def computeDynlibOfShared
         error s!"shared library `{sharedLib}` does not start with `lib`; this is not supported on Unix"
     else
       error s!"shared library `{sharedLib}` has no file name"
+
+partial def Module.transImports (mod : Module) : IndexBuildM (Array Module) :=
+  StateT.run' (σ := Lean.HashSet Module) (s := {}) do
+    go mod
+    return (← get).toArray
+where
+  go (mod : Module) := do
+    for mod in ← mod.imports.fetch do
+      if (← get).contains mod then continue
+      modify (·.insert mod)
+      go mod

--- a/Lake/Build/Executable.lean
+++ b/Lake/Build/Executable.lean
@@ -11,7 +11,7 @@ namespace Lake
 
 protected def LeanExe.recBuildExe
 (self : LeanExe) : IndexBuildM (BuildJob FilePath) := do
-  let (_, imports) ← self.root.imports.fetch
+  let imports ← self.root.transImports
   let mut linkJobs := #[← self.root.o.fetch]
   for mod in imports do for facet in mod.nativeFacets do
     linkJobs := linkJobs.push <| ← fetch <| mod.facet facet.name

--- a/Lake/Build/Info.lean
+++ b/Lake/Build/Info.lean
@@ -144,9 +144,9 @@ Defined here because they need to import configurations, whereas the definitions
 there need to be imported by configurations.
 -/
 
-/-- The direct × transitive imports of the Lean module. -/
+/-- The direct imports of the Lean module. -/
 abbrev Module.importFacet := `lean.imports
-module_data lean.imports : Array Module × Array Module
+module_data lean.imports : Array Module
 
 /-- The package's complete array of transitive dependencies. -/
 abbrev Package.depsFacet := `deps

--- a/Lake/Build/Library.lean
+++ b/Lake/Build/Library.lean
@@ -16,7 +16,7 @@ def LeanLib.recBuildLocalModules
   let mut modSet := ModuleSet.empty
   let mods ← self.getModuleArray
   for mod in mods do
-    let (_, mods) ← mod.imports.fetch
+    let mods ← mod.transImports
     let mods := mods.push mod
     for mod in mods do
       if self.isLocalModule mod.name then
@@ -58,7 +58,7 @@ def LeanLib.recBuildLinks
   let mut modSet := ModuleSet.empty
   let mods ← self.getModuleArray
   for mod in mods do
-    let (_, mods) ← mod.imports.fetch
+    let mods ← mod.transImports
     let mods := mods.push mod
     for mod in mods do
       unless modSet.contains mod do

--- a/Lake/CLI/Actions.lean
+++ b/Lake/CLI/Actions.lean
@@ -26,15 +26,16 @@ If no configuration file exists, exit silently with `noConfigFileCode` (i.e, 2).
 
 The `print-paths` command is used internally by Lean 4 server.
 -/
-def printPaths (config : LoadConfig) (imports : List String := []) (oldMode : Bool := false) : MainM PUnit := do
+def printPaths (config : LoadConfig) (imports : List String := [])
+(oldMode : Bool := false) (verbosity : Verbosity := .normal) : MainM PUnit := do
   let configFile := config.rootDir / config.configFile
   if (← configFile.pathExists) then
     if (← IO.getEnv invalidConfigEnvVar) matches some .. then
       IO.eprintln s!"Error parsing '{configFile}'.  Please restart the lean server after fixing the Lake configuration file."
       exit 1
-    let ws ← MainM.runLogIO (loadWorkspace config) config.verbosity
+    let ws ← MainM.runLogIO (loadWorkspace config) verbosity
     let dynlibs ← ws.runBuild (buildImportsAndDeps imports) oldMode
-      |>.run (MonadLog.eio config.verbosity)
+      |>.run (MonadLog.eio verbosity)
     IO.println <| Json.compress <| toJson {
       oleanPath := ws.leanPath
       srcPath := ws.leanSrcPath

--- a/Lake/CLI/Actions.lean
+++ b/Lake/CLI/Actions.lean
@@ -3,62 +3,9 @@ Copyright (c) 2022 Mac Malone. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mac Malone
 -/
-import Lake.Load
-import Lake.Build
-import Lake.Util.MainM
+import Lake.Build.Index
 
 namespace Lake
-open Lean (Json toJson fromJson? LeanPaths)
-
-/-- Exit code to return if `print-paths` cannot find the config file. -/
-def noConfigFileCode : ExitCode := 2
-
-/--
-Environment variable that is set when `lake serve` cannot parse the Lake configuration file
-and falls back to plain `lean --server`.
--/
-def invalidConfigEnvVar := "LAKE_INVALID_CONFIG"
-
-/--
-Build a list of imports of the package
-and print the `.olean` and source directories of every used package.
-If no configuration file exists, exit silently with `noConfigFileCode` (i.e, 2).
-
-The `print-paths` command is used internally by Lean 4 server.
--/
-def printPaths (config : LoadConfig) (imports : List String := [])
-(oldMode : Bool := false) (verbosity : Verbosity := .normal) : MainM PUnit := do
-  let configFile := config.rootDir / config.configFile
-  if (← configFile.pathExists) then
-    if (← IO.getEnv invalidConfigEnvVar) matches some .. then
-      IO.eprintln s!"Error parsing '{configFile}'.  Please restart the lean server after fixing the Lake configuration file."
-      exit 1
-    let ws ← MainM.runLogIO (loadWorkspace config) verbosity
-    let dynlibs ← ws.runBuild (buildImportsAndDeps imports) oldMode
-      |>.run (MonadLog.eio verbosity)
-    IO.println <| Json.compress <| toJson {
-      oleanPath := ws.leanPath
-      srcPath := ws.leanSrcPath
-      loadDynlibPaths := dynlibs
-      : LeanPaths
-    }
-  else
-    exit noConfigFileCode
-
-def serve (config : LoadConfig) (args : Array String) : LogIO UInt32 := do
-  let (extraEnv, moreServerArgs) ←
-    try
-      let ws ← loadWorkspace config
-      let ctx := mkLakeContext ws
-      pure (← LakeT.run ctx getAugmentedEnv, ws.root.moreServerArgs)
-    else
-      logWarning "package configuration has errors, falling back to plain `lean --server`"
-      pure (config.env.installVars.push (invalidConfigEnvVar, "1"), #[])
-  (← IO.Process.spawn {
-    cmd := config.env.lean.lean.toString
-    args := #["--server"] ++ moreServerArgs ++ args
-    env := extraEnv
-  }).wait
 
 def env (cmd : String) (args : Array String := #[]) : LakeT IO UInt32 := do
   IO.Process.spawn {cmd, args, env := ← getAugmentedEnv} >>= (·.wait)

--- a/Lake/CLI/Help.lean
+++ b/Lake/CLI/Help.lean
@@ -22,6 +22,7 @@ OPTIONS:
   --verbose, -v         show verbose information (command invocations)
   --lean=cmd            specify the `lean` command used by Lake
   -K key[=value]        set the configuration file option named key
+  --old                 only rebuild modified modules (ignore transitive deps)
 
 COMMANDS:
   new <name> [<temp>]   create a Lean package in a new directory

--- a/Lake/CLI/Help.lean
+++ b/Lake/CLI/Help.lean
@@ -105,7 +105,7 @@ USAGE:
   lake update
 
 This command sets up the directory with the package's dependencies
-(i.e., `packagesDir`, which is, by default, `lean_packages`).
+(i.e., `packagesDir`, which is, by default, `lake-packages`).
 
 For each (transitive) git dependency, the specified commit is checked out
 into a sub-directory of `packagesDir`. Already checked out dependencies are

--- a/Lake/CLI/Init.lean
+++ b/Lake/CLI/Init.lean
@@ -22,7 +22,6 @@ def toolchainFileName : FilePath :=
 def gitignoreContents :=
 s!"/{defaultBuildDir}
 /{defaultPackagesDir}/*
-!/{defaultPackagesDir}/{defaultManifestFileName}
 "
 
 def libFileContents :=

--- a/Lake/CLI/Main.lean
+++ b/Lake/CLI/Main.lean
@@ -13,6 +13,7 @@ import Lake.CLI.Help
 import Lake.CLI.Build
 import Lake.CLI.Error
 import Lake.CLI.Actions
+import Lake.CLI.Serve
 
 -- # CLI
 

--- a/Lake/CLI/Main.lean
+++ b/Lake/CLI/Main.lean
@@ -63,7 +63,6 @@ def LakeOptions.mkLoadConfig
     configFile := opts.rootDir / opts.configFile
     configOpts := opts.configOpts
     leanOpts := Lean.Options.empty
-    verbosity := opts.verbosity
     updateDeps
   }
 
@@ -261,7 +260,7 @@ protected def build : CliM PUnit := do
   let ws ← loadWorkspace config
   let targetSpecs ← takeArgs
   let specs ← parseTargetSpecs ws targetSpecs
-  ws.runBuild (buildSpecs specs) opts.oldMode |>.run (MonadLog.io config.verbosity)
+  ws.runBuild (buildSpecs specs) opts.oldMode |>.run (MonadLog.io opts.verbosity)
 
 protected def resolveDeps : CliM PUnit := do
   processOptions lakeOption
@@ -290,7 +289,7 @@ protected def printPaths : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
   let config ← mkLoadConfig opts
-  printPaths config (← takeArgs) opts.oldMode
+  printPaths config (← takeArgs) opts.oldMode opts.verbosity
 
 protected def clean : CliM PUnit := do
   processOptions lakeOption

--- a/Lake/CLI/Serve.lean
+++ b/Lake/CLI/Serve.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2022 Mac Malone. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mac Malone
+-/
+import Lake.Load
+import Lake.Build
+import Lake.Util.MainM
+
+namespace Lake
+open Lean (Json toJson fromJson? LeanPaths)
+
+/-- Exit code to return if `print-paths` cannot find the config file. -/
+def noConfigFileCode : ExitCode := 2
+
+/--
+Environment variable that is set when `lake serve` cannot parse the Lake configuration file
+and falls back to plain `lean --server`.
+-/
+def invalidConfigEnvVar := "LAKE_INVALID_CONFIG"
+
+/--
+Build a list of imports of the package
+and print the `.olean` and source directories of every used package.
+If no configuration file exists, exit silently with `noConfigFileCode` (i.e, 2).
+
+The `print-paths` command is used internally by Lean 4 server.
+-/
+def printPaths (config : LoadConfig) (imports : List String := [])
+(oldMode : Bool := false) (verbosity : Verbosity := .normal) : MainM PUnit := do
+  let configFile := config.rootDir / config.configFile
+  if (← configFile.pathExists) then
+    if (← IO.getEnv invalidConfigEnvVar) matches some .. then
+      IO.eprintln s!"Error parsing '{configFile}'.  Please restart the lean server after fixing the Lake configuration file."
+      exit 1
+    let ws ← MainM.runLogIO (loadWorkspace config) verbosity
+    let dynlibs ← ws.runBuild (buildImportsAndDeps imports) oldMode
+      |>.run (MonadLog.eio verbosity)
+    IO.println <| Json.compress <| toJson {
+      oleanPath := ws.leanPath
+      srcPath := ws.leanSrcPath
+      loadDynlibPaths := dynlibs
+      : LeanPaths
+    }
+  else
+    exit noConfigFileCode
+
+/--
+Start the Lean LSP for the `Workspace` loaded from `config`
+with the given additional `args`.
+-/
+def serve (config : LoadConfig) (args : Array String) : LogIO UInt32 := do
+  let (extraEnv, moreServerArgs) ←
+    try
+      let ws ← loadWorkspace config
+      let ctx := mkLakeContext ws
+      pure (← LakeT.run ctx getAugmentedEnv, ws.root.moreServerArgs)
+    else
+      logWarning "package configuration has errors, falling back to plain `lean --server`"
+      pure (config.env.installVars.push (invalidConfigEnvVar, "1"), #[])
+  (← IO.Process.spawn {
+    cmd := config.env.lean.lean.toString
+    args := #["--server"] ++ moreServerArgs ++ args
+    env := extraEnv
+  }).wait

--- a/Lake/Config/LeanLib.lean
+++ b/Lake/Config/LeanLib.lean
@@ -69,6 +69,10 @@ Is true if either the package or the library have `precompileModules` set.
 @[inline] def precompileModules (self : LeanLib) : Bool :=
   self.pkg.precompileModules || self.config.precompileModules
 
+/-- The library's `defaultFacets` configuration. -/
+@[inline] def defaultFacets (self : LeanLib) : Array Name :=
+  self.config.defaultFacets
+
 /-- The library's `nativeFacets` configuration. -/
 @[inline] def nativeFacets (self : LeanLib) : Array (ModuleFacet (BuildJob FilePath)) :=
   self.config.nativeFacets

--- a/Lake/Config/LeanLibConfig.lean
+++ b/Lake/Config/LeanLibConfig.lean
@@ -62,6 +62,12 @@ structure LeanLibConfig extends LeanConfig where
   precompileModules : Bool := false
 
   /--
+  An `Array` of library facets to build on a bare `lake build` of the library.
+  For example, `#[LeanLib.sharedLib]` will build the shared library facet.
+  -/
+  defaultFacets : Array Name := #[LeanLib.leanFacet]
+
+  /--
   An `Array` of module facets to build and combine into the library's static
   and shared libraries. Defaults to ``#[Module.oFacet]`` (i.e., the object file
   compiled from the Lean source).

--- a/Lake/Config/Module.lean
+++ b/Lake/Config/Module.lean
@@ -20,6 +20,9 @@ structure Module where
   keyName : Name := name
   deriving Inhabited
 
+instance : Hashable Module where hash m := hash m.name
+instance : BEq Module where beq m n := m.name == n.name
+
 abbrev ModuleSet := RBTree Module (·.name.quickCmp ·.name)
 @[inline] def ModuleSet.empty : ModuleSet := RBTree.empty
 

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -42,8 +42,8 @@ def nameToArchive (name? : Option String) : String :=
 /-! # Defaults -/
 --------------------------------------------------------------------------------
 
-/-- The default name of the package manifest. -/
-def defaultManifestFileName := "manifest.json"
+/-- The default setting for a `PackageConfig`'s `manifestFile` option. -/
+def defaultManifestFile := "lake-manifest.json"
 
 /-- The default setting for a `PackageConfig`'s `buildDir` option. -/
 def defaultBuildDir : FilePath := "build"
@@ -74,9 +74,9 @@ structure PackageConfig extends WorkspaceConfig, LeanConfig where
   The path of a package's manifest file, which stores the exact versions
   of its resolved dependencies.
 
-  Defaults to `packagesDir` / `defaultManifestFileName` (i.e., `manifest.json`).
+  Defaults to `defaultManifestFile` (i.e., `lake-manifest.json`).
   -/
-  manifestFile := packagesDir / defaultManifestFileName
+  manifestFile := defaultManifestFile
 
   /-- An `Array` of target names to build whenever the package is used. -/
   extraDepTargets : Array Name := #[]

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -206,8 +206,6 @@ structure Package where
   scripts : NameMap Script := {}
   deriving Inhabited
 
-#check String.dropRight
-
 hydrate_opaque_type OpaquePackage Package
 
 abbrev PackageSet := RBTree Package (·.config.name.quickCmp ·.config.name)

--- a/Lake/Config/WorkspaceConfig.lean
+++ b/Lake/Config/WorkspaceConfig.lean
@@ -8,13 +8,13 @@ open System
 namespace Lake
 
 /-- The default setting for a `WorkspaceConfig`'s `packagesDir` option. -/
-def defaultPackagesDir : FilePath := "lean_packages"
+def defaultPackagesDir : FilePath := "lake-packages"
 
 /-- A `Workspace`'s declarative configuration. -/
 structure WorkspaceConfig where
   /--
   The directory to which Lake should download remote dependencies.
-  Defaults to `defaultPackagesDir` (i.e., `lean_packages`).
+  Defaults to `defaultPackagesDir` (i.e., `lake-packages`).
   -/
   packagesDir : FilePath := defaultPackagesDir
   deriving Inhabited, Repr

--- a/Lake/Load/Config.lean
+++ b/Lake/Load/Config.lean
@@ -26,8 +26,6 @@ structure LoadConfig where
   configOpts : NameMap String := {}
   /-- The Lean options with which to elaborate the configuration file. -/
   leanOpts : Options := {}
-  /-- The verbosity setting for logging messages. -/
-  verbosity : Verbosity := .normal
   /--
   Whether to update dependencies during resolution
   or fallback to the ones listed in the manifest.

--- a/Lake/Util/Binder.lean
+++ b/Lake/Util/Binder.lean
@@ -145,7 +145,6 @@ def BinderSyntaxView.mkBinder : BinderSyntaxView → MacroM Binder
   | .implicit       => `(binder| {$id : $type})
   | .strictImplicit => `(binder| ⦃$id : $type⦄)
   | .instImplicit   => `(binder| [$id : $type])
-  | _               => unreachable!
 
 def BinderSyntaxView.mkArgument : BinderSyntaxView → MacroM NamedArgument
 | {id, ..} => `(Term.namedArgument| ($id := $id))

--- a/Lake/Version.lean
+++ b/Lake/Version.lean
@@ -7,10 +7,10 @@ Authors: Mac Malone
 namespace Lake
 
 def version.major := 4
-def version.minor := 0
+def version.minor := 1
 def version.patch := 0
 
-def version.isPrerelease := false
+def version.isPrerelease := true
 def version.isRelease := !isPrerelease
 def version.specialDesc := if isPrerelease then "pre" else ""
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-examples: test-init test-hello test-deps\
 
 test-bootstrapped: test-boostrapped-hello
 
-clean: clean-build clean-tests clean-examples
+clean: clean-tests clean-examples clean-build
 
 clean-tests: clean-44 clean-62 clean-102 clean-104 clean-manifest
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Lake provides a large assortment of configuration options for packages.
 
 ### Layout
 
-* `packagesDir`: The directory to which Lake should download remote dependencies. Defaults to `lean_packages`.
-* `manifestFile`: The path of a package's manifest file, which stores the exact versions of its resolved dependencies. Defaults to `lean_packages/manifest.json`.
+* `packagesDir`: The directory to which Lake should download remote dependencies. Defaults to `lake-packages`.
+* `manifestFile`: The path of a package's manifest file, which stores the exact versions of its resolved dependencies. Defaults to `lake-manifest.json`.
 * `srcDir`: The directory containing the package's Lean source files. Defaults to the package's directory. (This will be passed to `lean` as the `-R` option.)
 * `buildDir`: The directory to which Lake should output the package's build results. Defaults to `build`.
 * `oleanDir`: The build subdirectory to which Lake should output the package's `.olean` files. Defaults to `lib`.
@@ -265,7 +265,7 @@ require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git"
 ```
 
-The next run of `lake build` (or refreshing dependencies in an editor like VSCode) will clone the mathlib repository and build it. Information on the specific revision cloned will then be saved to `manifest.json` in the workspace's `packageDir` (by default, `lean_packages`) to enable reproducibility. To update `mathlib` after this, you will need to run `lake update` -- other commands do not update resolved dependencies.
+The next run of `lake build` (or refreshing dependencies in an editor like VSCode) will clone the mathlib repository and build it. Information on the specific revision cloned will then be saved to `lake-manifest.json` to enable reproducibility. To update `mathlib` after this, you will need to run `lake update` -- other commands do not update resolved dependencies.
 
 For a theorem proving packages which depend on `mathlib`, you can also run `lake new <package-name> math` to generate a package configuration file that already has the `mathlib` dependency (and no binary executable target).
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ lean_lib «target-name» {
 * `roots`: An `Array` of root module `Name`(s) of the library. Submodules of these roots (e.g., `Lib.Foo` of `Lib`) are considered part of the library. Defaults to a single root of the library's upper camel case name.
 * `globs`: An `Array` of module `Glob`s to build for the library. Defaults to a `Glob.one` of each of the library's  `roots`. Submodule globs build every source file within their directory. Local imports of glob'ed files (i.e., fellow modules of the workspace) are also recursively built.
 * `libName`: The `String` name of the library. Used as a base for the file names of its static and dynamic binaries. Defaults to the upper camel case name of the target.
+* `defaultFacets`: An `Array` of library facets to build on a bare `lake build` of the library. For example, setting this to `#[LeanLib.sharedLib]` will build the shared library facet.
 * `nativeFacets`: An `Array` of [module facets](#defining-new-facets) to build and combine into the library's static and shared libraries. Defaults to ``#[Module.oFacet]`` (i.e., the object file compiled from the Lean source).
 * `precompileModules`, `buildType`, `moreLeanArgs`, `moreLinkArgs`, `moreLinkArgs`: Augments the package's corresponding configuration option. The library's arguments come after, modules are precompiled if either the library or package are precompiled, and the build type is the minimum of the two (`debug` is the lowest, and `release` is the highest)
 

--- a/examples/ffi/lib/lakefile.lean
+++ b/examples/ffi/lib/lakefile.lean
@@ -15,9 +15,8 @@ lean_lib FFI
 target ffi.o (pkg : Package) : FilePath := do
   let oFile := pkg.buildDir / "c" / "ffi.o"
   let srcJob ← inputFile <| pkg.dir / "c" / "ffi.cpp"
-  buildFileAfterDep oFile srcJob fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
-    compileO "ffi.c" oFile srcFile flags "c++"
+  let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+  buildO "ffi.c" oFile srcJob flags "c++"
 
 extern_lib libleanffi (pkg : Package) := do
   let name := nameToStaticLib "leanffi"

--- a/examples/ffi/package.sh
+++ b/examples/ffi/package.sh
@@ -1,10 +1,10 @@
 set -ex
 
 cd app
-${LAKE:-../../../build/bin/lake} build
+${LAKE:-../../../build/bin/lake} build -v
 cd ..
 
 
 cd lib
-${LAKE:-../../../build/bin/lake} build
+${LAKE:-../../../build/bin/lake} build -v
 cd ..

--- a/examples/ffi/test.sh
+++ b/examples/ffi/test.sh
@@ -5,4 +5,4 @@ set -e
 ./app/build/bin/app
 ./lib/build/bin/test
 
-${LAKE:-../../build/bin/lake} -d app build Test
+${LAKE:-../../build/bin/lake} -d app build -v Test

--- a/examples/git/.gitignore
+++ b/examples/git/.gitignore
@@ -1,2 +1,3 @@
 /build
-/lean_packages
+/lake-packages
+lake-manifest.json

--- a/examples/git/clean.sh
+++ b/examples/git/clean.sh
@@ -1,2 +1,2 @@
 rm -rf build
-rm -rf lean_packages
+rm -rf lake-packages

--- a/examples/hello/clean.sh
+++ b/examples/hello/clean.sh
@@ -1,1 +1,1 @@
-${LAKE:-../../build/bin/lake} clean
+rm -rf build

--- a/examples/targets/lakefile.lean
+++ b/examples/targets/lakefile.lean
@@ -6,8 +6,14 @@ package targets {
 }
 
 @[defaultTarget]
-lean_lib foo
-lean_lib bar
+lean_lib foo {
+  defaultFacets := #[LeanLib.staticFacet]
+}
+
+lean_lib bar{
+  defaultFacets := #[LeanLib.sharedFacet]
+}
+
 lean_lib baz
 
 lean_exe a

--- a/examples/targets/test.sh
+++ b/examples/targets/test.sh
@@ -33,18 +33,20 @@ $LAKE build targets/
 
 ./build/bin/c
 test -f ./build/lib/Foo.olean
+test -f ./build/lib/${LIB_PREFIX}Foo.a
 cat ./build/meow.txt | grep -m1 Meow!
+
+$LAKE build foo:shared bar
+
+test -f ./build/lib/${LIB_PREFIX}Foo.$SHARED_LIB_EXT
+test -f ./build/lib/${LIB_PREFIX}Bar.$SHARED_LIB_EXT
+
+test ! -f ./build/lib/Baz.olean
 
 $LAKE build a b
 
 ./build/bin/a
 ./build/bin/b
-
-$LAKE build foo:static
-$LAKE build bar:shared
-
-test -f ./build/lib/${LIB_PREFIX}Foo.a
-test -f ./build/lib/${LIB_PREFIX}Bar.$SHARED_LIB_EXT
 
 $LAKE build bark | grep -m1 Bark!
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-09-28
+leanprover/lean4:nightly-2022-10-13

--- a/test/102/.gitignore
+++ b/test/102/.gitignore
@@ -1,3 +1,1 @@
 /build
-/lean_packages/*
-!/lean_packages/manifest.json

--- a/test/104/clean.sh
+++ b/test/104/clean.sh
@@ -1,3 +1,3 @@
 rm -rf test/build
-rm -rf test/lean_packages
+rm -rf test/lake-packages
 rm -f lake-manifest.json

--- a/test/104/clean.sh
+++ b/test/104/clean.sh
@@ -1,2 +1,3 @@
 rm -rf test/build
 rm -rf test/lean_packages
+rm -f lake-manifest.json

--- a/test/104/test.sh
+++ b/test/104/test.sh
@@ -17,5 +17,5 @@ else
   sed -i "s,\\.\\.[^\"]*,$TEST_URL," $MANIFEST
 fi
 cat $MANIFEST
-git -C lean_packages/hello remote set-url origin $TEST_URL
+git -C lake-packages/hello remote set-url origin $TEST_URL
 $LAKE build -K url=$TEST_URL

--- a/test/104/test.sh
+++ b/test/104/test.sh
@@ -4,17 +4,18 @@ set -exo pipefail
 LAKE=${LAKE:-../../../build/bin/lake}
 
 TEST_URL=https://example.com/hello.git
+MANIFEST=lake-manifest.json
 
 ./clean.sh
 
 cd test
 $LAKE build
-cat lean_packages/manifest.json
+cat $MANIFEST
 if [ "`uname`" = Darwin ]; then
-  sed -i '' "s,\\.\\.[^\"]*,$TEST_URL," lean_packages/manifest.json
+  sed -i '' "s,\\.\\.[^\"]*,$TEST_URL," $MANIFEST
 else
-  sed -i "s,\\.\\.[^\"]*,$TEST_URL," lean_packages/manifest.json
+  sed -i "s,\\.\\.[^\"]*,$TEST_URL," $MANIFEST
 fi
-cat lean_packages/manifest.json
+cat $MANIFEST
 git -C lean_packages/hello remote set-url origin $TEST_URL
 $LAKE build -K url=$TEST_URL

--- a/test/104/test/.gitignore
+++ b/test/104/test/.gitignore
@@ -1,2 +1,3 @@
 /build
 /lean_packages
+lake-manifest.json

--- a/test/104/test/.gitignore
+++ b/test/104/test/.gitignore
@@ -1,3 +1,3 @@
 /build
-/lean_packages
+/lake-packages
 lake-manifest.json

--- a/test/75/foo/.gitignore
+++ b/test/75/foo/.gitignore
@@ -1,6 +1,4 @@
 /build
-/lean_packages/*
-!/lean_packages/manifest.json
 
 /Foo.lean
 /Foo/Test.lean


### PR DESCRIPTION
Addresses #130.  Reduces the runtime of the benchmark in #130 from 8.4s to 1.7s on my laptop.