### PR TITLE
perf: use parseImports'

### DIFF
--- a/Lake/Build/Module.lean
+++ b/Lake/Build/Module.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Ullrich, Mac Malone
 -/
-import Lean.Elab.Import
+import Lean.Elab.ParseImportsFast
 import Lake.Build.Common
 
 open System
@@ -170,7 +170,7 @@ def Module.recParseImports (mod : Module)
   let mut directImports := #[]
   let mut importSet := ModuleSet.empty
   let contents ← IO.FS.readFile mod.leanFile
-  let (imports, _, _) ← Lean.Elab.parseImports contents mod.leanFile.toString
+  let imports ← Lean.parseImports' contents mod.leanFile.toString
   for imp in imports do
     if let some mod ← findModule? imp.module then
       let (_, impTransImports) ← mod.imports.fetch

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-10-25
+leanprover/lean4:nightly-2022-11-10


### PR DESCRIPTION
This uses the new dedicated import parsing function which is 10x faster than `parseImports`.