### PR TITLE
refactor: split code for lake update and lake build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Check Lake
       run: make check-lake
     - name: Test Lake
-      run: make test-ci -j4
+      run: make test-ci
     - name: Time Bootstrap
       run: make time-bootstrap
     - name: Check Bootstrap

--- a/Lake/CLI/Main.lean
+++ b/Lake/CLI/Main.lean
@@ -56,15 +56,13 @@ def LakeOptions.computeEnv (opts : LakeOptions) : EIO CliError Lake.Env := do
   Env.compute (← opts.getLakeInstall) (← opts.getLeanInstall)
 
 /-- Make a `LoadConfig` from a `LakeOptions`. -/
-def LakeOptions.mkLoadConfig
-(opts : LakeOptions) (updateDeps := false) : EIO CliError LoadConfig :=
+def LakeOptions.mkLoadConfig (opts : LakeOptions) : EIO CliError LoadConfig :=
   return {
     env := ← opts.computeEnv
     rootDir := opts.rootDir
     configFile := opts.rootDir / opts.configFile
     configOpts := opts.configOpts
     leanOpts := Lean.Options.empty
-    updateDeps
   }
 
 export LakeOptions (mkLoadConfig)
@@ -266,16 +264,16 @@ protected def build : CliM PUnit := do
 protected def resolveDeps : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
-  let config ← mkLoadConfig opts (updateDeps := false)
+  let config ← mkLoadConfig opts
   noArgsRem do
     liftM <| discard <| (loadWorkspace config).run (MonadLog.io opts.verbosity)
 
 protected def update : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
-  let config ← mkLoadConfig opts (updateDeps := true)
+  let config ← mkLoadConfig opts
   noArgsRem do
-    liftM <| discard <| (loadWorkspace config).run (MonadLog.io opts.verbosity)
+    liftM <| (updateManifest config).run (MonadLog.io opts.verbosity)
 
 protected def upload : CliM PUnit := do
   processOptions lakeOption

--- a/Lake/Load/Config.lean
+++ b/Lake/Load/Config.lean
@@ -26,8 +26,3 @@ structure LoadConfig where
   configOpts : NameMap String := {}
   /-- The Lean options with which to elaborate the configuration file. -/
   leanOpts : Options := {}
-  /--
-  Whether to update dependencies during resolution
-  or fallback to the ones listed in the manifest.
-  -/
-  updateDeps : Bool := false

--- a/Lake/Load/Materialize.lean
+++ b/Lake/Load/Materialize.lean
@@ -66,19 +66,19 @@ structure MaterializeResult where
 /--
 Materializes a package entry, cloning and/or checkout it out as necessary.
 -/
-def materializePackageEntry (rootPkg : Package) (manifestEntry : PackageEntry) : LogIO MaterializeResult :=
+def materializePackageEntry (rootPkgDir packagesDir : FilePath) (manifestEntry : PackageEntry) : LogIO MaterializeResult :=
   match manifestEntry with
   | .path _name pkgDir =>
     return {
-      pkgDir := rootPkg.dir / pkgDir
+      pkgDir := rootPkgDir / pkgDir
       relPkgDir := pkgDir
       remoteUrl? := none
       gitTag? := none
       manifestEntry
     }
   | .git name url rev _inputRev? subDir? => do
-    let relGitDir := rootPkg.config.packagesDir / name
-    let gitDir := rootPkg.dir / relGitDir
+    let relGitDir := packagesDir / name
+    let gitDir := rootPkgDir / relGitDir
     let repo := GitRepo.mk gitDir
     /-
     Do not update (fetch remote) if already on revision
@@ -94,7 +94,7 @@ def materializePackageEntry (rootPkg : Package) (manifestEntry : PackageEntry) :
       updateGitRepo repo url rev name
     let relPkgDir := match subDir? with | .some subDir => relGitDir / subDir | .none => relGitDir
     return {
-      pkgDir := rootPkg.dir / relPkgDir
+      pkgDir := rootPkgDir / relPkgDir
       relPkgDir
       remoteUrl? := url
       gitTag? := ← repo.findTag?

--- a/Lake/Util/Git.lean
+++ b/Lake/Util/Git.lean
@@ -83,6 +83,9 @@ def cwd : GitRepo := ⟨"."⟩
 @[inline] def headRevision (repo : GitRepo) : LogIO String :=
   repo.resolveRevision "HEAD"
 
+@[inline] def headRevision? (repo : GitRepo) : BaseIO (Option String) :=
+  repo.resolveRevision? "HEAD"
+
 def resolveRemoteRevision (rev : String) (remote := Git.defaultRemote) (repo : GitRepo) : LogIO String := do
   if Git.isFullObjectName rev then return rev
   if let some rev ← repo.resolveRevision? s!"{remote}/{rev}"  then return rev

--- a/Lake/Util/Log.lean
+++ b/Lake/Util/Log.lean
@@ -96,6 +96,9 @@ abbrev MonadLogT.adaptMethods [Monad n]
 (f : MonadLog m → MonadLog m') (self : MonadLogT m' n α) : MonadLogT m n α :=
   ReaderT.adapt f self
 
+abbrev MonadLogT.ignoreLog [Pure m] (self : MonadLogT m n α) : n α :=
+  self MonadLog.nop
+
 abbrev LogIO :=
   MonadLogT BaseIO OptionIO
 

--- a/examples/deps/package.sh
+++ b/examples/deps/package.sh
@@ -1,10 +1,12 @@
 set -ex
 
 cd bar
+${LAKE:-../../../build/bin/lake} update
 ${LAKE:-../../../build/bin/lake} build
 cd ..
 
 
 cd foo
+${LAKE:-../../../build/bin/lake} update
 ${LAKE:-../../../build/bin/lake} build
 cd ..

--- a/examples/ffi/package.sh
+++ b/examples/ffi/package.sh
@@ -1,6 +1,7 @@
 set -ex
 
 cd app
+${LAKE:-../../../build/bin/lake} update -v
 ${LAKE:-../../../build/bin/lake} build -v
 cd ..
 

--- a/examples/ffi/test.sh
+++ b/examples/ffi/test.sh
@@ -1,4 +1,4 @@
-set -e
+set -ex
 
 ./clean.sh
 ./package.sh

--- a/examples/git/package.sh
+++ b/examples/git/package.sh
@@ -1,1 +1,2 @@
+${LAKE:-../../build/bin/lake} update
 ${LAKE:-../../build/bin/lake} build

--- a/examples/precompile/test.sh
+++ b/examples/precompile/test.sh
@@ -3,5 +3,6 @@ set -ex
 LAKE=${LAKE:-../../build/bin/lake}
 
 ./clean.sh
+$LAKE -d bar update
 $LAKE -d bar build # tests #83
 $LAKE -d foo build

--- a/test/104/test.sh
+++ b/test/104/test.sh
@@ -9,6 +9,7 @@ MANIFEST=lake-manifest.json
 ./clean.sh
 
 cd test
+$LAKE update
 $LAKE build
 cat $MANIFEST
 if [ "`uname`" = Darwin ]; then

--- a/test/manifest/test.sh
+++ b/test/manifest/test.sh
@@ -61,7 +61,8 @@ cat >>lakefile.lean <<EOF
 require b from git "../b" @ "master"
 require c from git "../c" @ "master"
 EOF
-$LAKE update -v 2>&1 | grep -m8 -E '`[abc]`|master'
+# make sure we pick up the version from b's manifest, and not current master
+$LAKE update -v 2>&1 | grep 'first commit in a'
 git add .
 git config user.name test
 git config user.email test@example.com
@@ -75,7 +76,7 @@ pushd b
 $LAKE update -v
 git diff | grep -m1 manifest
 sed_i 's/master/init/g' lakefile.lean
-$LAKE resolve-deps -v 2>&1 | grep -m1 'listed in manifest does not match `init`'
+$LAKE resolve-deps -v 2>&1 | grep 'manifest out of date'
 git reset --hard
 popd
 


### PR DESCRIPTION
Fixes #119 and fixes #137.

The code for `lake update` and `lake build` is now completely disjoint.  `lake build` will never modify the manifest, and `lake update` always builds the manifest from scratch.  (Which replaces the `rm lean_packages/manifest.json` hack I've been putting into lean3port/mathlib3port.)

The resolution policy is changed to "first revision wins" (going from the root package to the leaves of the dependency tree).  If the root package specifies a dependency, then this dependency is always updated and overrides dependencies with the same name in dependent packages (e.g. std4 in mathlib4, which is imported both directly and transitively via aesop).

Local dependencies (`.path`) are now stored in the manifest as well.  The manifest thus always contains the full information about where all the dependencies come from.  When running `lake build`, dependencies are resolved by only looking at the manifest.

There is a bit of complication due to the `-d` flag.  Since we don't have `IO.FS.chdir` but want to store relative paths in the `manifest.json` file, we need to keep two books during `lake update`, one for the relative paths (relative to the root package) and one for the actual paths relative to the current directory (this is `MaterializeResult.pkgDir` vs. `MaterializeResult.relPkgDir`).