### PR TITLE
perf: use ByteArray.hash

### DIFF
--- a/Lake/Build/Trace.lean
+++ b/Lake/Build/Trace.lean
@@ -108,8 +108,8 @@ instance : ToString Hash := ⟨Hash.toString⟩
 def ofString (str : String) :=
   mix nil <| mk <| hash str -- same as Name.mkSimple
 
-def ofByteArray (bytes : ByteArray) :=
-  bytes.foldl (init := nil) fun h b => mix h (mk <| hash b)
+def ofByteArray (bytes : ByteArray) : Hash :=
+  ⟨hash bytes⟩
 
 end Hash
 


### PR DESCRIPTION
Before: 
```
$ time ~/lake/build/bin/lake print-paths Inundation
{"srcPath":["./."],"oleanPath":["./build/lib"],"loadDynlibPaths":[]}
1.86user 2.18system 0:02.14elapsed 188%CPU (0avgtext+0avgdata 351428maxresident)k
26920inputs+25616outputs (10major+23928minor)pagefaults 0swaps
```

After:
```
$ time ~/lake/build/bin/lake print-paths Inundation
{"srcPath":["./."],"oleanPath":["./build/lib"],"loadDynlibPaths":[]}
0.71user 1.06system 0:00.64elapsed 278%CPU (0avgtext+0avgdata 347028maxresident)k
0inputs+25616outputs (0major+23997minor)pagefaults 0swaps
```

So another 2.6x improvement!