### PR TITLE
fix: adapt to new `Handle.mk` signature

### DIFF
--- a/Lake/CLI/Init.lean
+++ b/Lake/CLI/Init.lean
@@ -183,7 +183,7 @@ def initPkg (dir : FilePath) (name : String) (tmp : InitTemplate) : LogIO PUnit 
       IO.FS.writeFile (dir / toolchainFileName) <| Lean.toolchain ++ "\n"
 
   -- update `.gitignore` with additional entries for Lake
-  let h ← IO.FS.Handle.mk (dir / ".gitignore") IO.FS.Mode.append (bin := false)
+  let h ← IO.FS.Handle.mk (dir / ".gitignore") IO.FS.Mode.append
   h.putStr gitignoreContents
 
   -- initialize a `.git` repository if none already


### PR DESCRIPTION
The previous code was arguably wrong in any case as the result of `lake init` should not depend on the current platform