### PR TITLE
chore: don't rely on simp calling decide

### DIFF
--- a/Lake/Util/Name.lean
+++ b/Lake/Util/Name.lean
@@ -23,7 +23,7 @@ namespace Name
 open Lean.Name
 
 @[simp] protected theorem beq_false (m n : Name) : (m == n) = false ↔ ¬ (m = n) := by
-  rw [← beq_iff_eq m n]; cases m == n <;> simp <;> decide
+  rw [← beq_iff_eq m n]; cases m == n <;> simp (config := { decide := true })
 
 @[simp] theorem isPrefixOf_self {n : Name} : n.isPrefixOf n := by
   cases n <;> simp [isPrefixOf]

--- a/Lake/Util/Name.lean
+++ b/Lake/Util/Name.lean
@@ -23,7 +23,7 @@ namespace Name
 open Lean.Name
 
 @[simp] protected theorem beq_false (m n : Name) : (m == n) = false ↔ ¬ (m = n) := by
-  rw [← beq_iff_eq m n]; cases m == n <;> simp
+  rw [← beq_iff_eq m n]; cases m == n <;> simp <;> decide
 
 @[simp] theorem isPrefixOf_self {n : Name} : n.isPrefixOf n := by
   cases n <;> simp [isPrefixOf]


### PR DESCRIPTION
I am trying to change the default behaviour in `simp` from `{ decide := true }` to `{ decide := false }`. 

See
* https://github.com/leanprover/lean4/pull/2166
* https://github.com/leanprover/lean4/pull/2068

I think I've got all the patches to Lean4 required, except that I need to make a simultaneous change to `lake` in order to pass CI! (Oh what a tangled web we weave...)

This simple PR makes Lake agnostic to the default behaviour in Lean, compiling successfully either before or after the change. If it is okay to merge this, then hopefully I can proceed with the rest.