### PR TITLE
Add progress information during builds

### DIFF
--- a/Lake/Build/Actions.lean
+++ b/Lake/Build/Actions.lean
@@ -5,6 +5,7 @@ Authors: Gabriel Ebner, Sebastian Ullrich, Mac Malone
 -/
 import Lake.Util.Proc
 import Lake.Util.NativeLib
+import Lake.Build.Context
 
 namespace Lake
 open System
@@ -17,8 +18,8 @@ def compileLeanModule (name : String) (leanFile : FilePath)
 (leanPath : SearchPath := []) (rootDir : FilePath := ".")
 (dynlibs : Array FilePath := #[]) (dynlibPath : SearchPath := {})
 (leanArgs : Array String := #[]) (lean : FilePath := "lean")
-: LogIO PUnit := do
-  logInfo s!"Building {name}"
+: BuildM Unit := do
+  logStep s!"Building {name}"
   let mut args := leanArgs ++
     #[leanFile.toString, "-R", rootDir.toString]
   if let some oleanFile := oleanFile? then
@@ -42,8 +43,8 @@ def compileLeanModule (name : String) (leanFile : FilePath)
   }
 
 def compileO (name : String) (oFile srcFile : FilePath)
-(moreArgs : Array String := #[]) (compiler : FilePath := "cc") : LogIO Unit := do
-  logInfo s!"Compiling {name}"
+(moreArgs : Array String := #[]) (compiler : FilePath := "cc") : BuildM Unit := do
+  logStep s!"Compiling {name}"
   createParentDirs oFile
   proc {
     cmd := compiler.toString
@@ -51,8 +52,8 @@ def compileO (name : String) (oFile srcFile : FilePath)
   }
 
 def compileStaticLib (name : String) (libFile : FilePath)
-(oFiles : Array FilePath) (ar : FilePath := "ar") : LogIO Unit := do
-  logInfo s!"Creating {name}"
+(oFiles : Array FilePath) (ar : FilePath := "ar") : BuildM Unit := do
+  logStep s!"Creating {name}"
   createParentDirs libFile
   proc {
     cmd := ar.toString
@@ -60,8 +61,8 @@ def compileStaticLib (name : String) (libFile : FilePath)
   }
 
 def compileSharedLib (name : String) (libFile : FilePath)
-(linkArgs : Array String) (linker : FilePath := "cc") : LogIO Unit := do
-  logInfo s!"Linking {name}"
+(linkArgs : Array String) (linker : FilePath := "cc") : BuildM Unit := do
+  logStep s!"Linking {name}"
   createParentDirs libFile
   proc {
     cmd := linker.toString
@@ -69,8 +70,8 @@ def compileSharedLib (name : String) (libFile : FilePath)
   }
 
 def compileExe (name : String) (binFile : FilePath) (linkFiles : Array FilePath)
-(linkArgs : Array String := #[]) (linker : FilePath := "cc") : LogIO Unit := do
-  logInfo s!"Linking {name}"
+(linkArgs : Array String := #[]) (linker : FilePath := "cc") : BuildM Unit := do
+  logStep s!"Linking {name}"
   createParentDirs binFile
   proc {
     cmd := linker.toString

--- a/Lake/Build/Facets.lean
+++ b/Lake/Build/Facets.lean
@@ -47,9 +47,8 @@ instance [FamilyDef ModuleData facet α] : CoeDep Name facet (ModuleFacet α) :=
 
 /--
 The core compilation / elaboration of the Lean file via `lean`,
-which produce the Lean binaries of the module (i.e., `olean` and `ilean`).
+which produce the Lean binaries of the module (i.e., `olean`, `ilean`, `c`).
 It is thus the facet used by default for building imports of a module.
-Also, if the module is not lean-only, it produces `c` files as well.
 -/
 abbrev Module.leanBinFacet := `bin
 module_data bin : BuildJob Unit

--- a/Lake/Build/Facets.lean
+++ b/Lake/Build/Facets.lean
@@ -48,10 +48,18 @@ instance [FamilyDef ModuleData facet α] : CoeDep Name facet (ModuleFacet α) :=
 /--
 The core compilation / elaboration of the Lean file via `lean`,
 which produce the Lean binaries of the module (i.e., `olean`, `ilean`, `c`).
-It is thus the facet used by default for building imports of a module.
+Its trace just includes its dependencies.
 -/
 abbrev Module.leanBinFacet := `bin
 module_data bin : BuildJob Unit
+
+/--
+The `leanBinFacet` combined with the module's trace
+(i.e., the trace of its `olean` and `ilean`).
+It is the facet used for building Lean imports of a module.
+-/
+abbrev Module.importBinFacet := `importBin
+module_data importBin : BuildJob Unit
 
 /-- The `olean` file produced by `lean`  -/
 abbrev Module.oleanFacet := `olean

--- a/Lake/Build/Info.lean
+++ b/Lake/Build/Info.lean
@@ -188,6 +188,7 @@ abbrev imports            := self.facet importsFacet
 abbrev transImports       := self.facet transImportsFacet
 abbrev precompileImports  := self.facet precompileImportsFacet
 abbrev leanBin            := self.facet leanBinFacet
+abbrev importBin          := self.facet importBinFacet
 abbrev olean              := self.facet oleanFacet
 abbrev ilean              := self.facet ileanFacet
 abbrev c                  := self.facet cFacet

--- a/Lake/Build/Job.lean
+++ b/Lake/Build/Job.lean
@@ -31,8 +31,8 @@ namespace Job
   await self
 
 @[inline] protected def bindSync
-(self : Job α) (f : α → JobM β) : SchedulerM (Job β) :=
-  bindSync self f
+(self : Job α) (f : α → JobM β) (prio := Task.Priority.default) : SchedulerM (Job β) :=
+  bindSync prio self f
 
 @[inline] protected def bindAsync
 (self : Job α) (f : α → SchedulerM (Job β)) : SchedulerM (Job β)  :=
@@ -69,8 +69,9 @@ instance : Functor BuildJob where
   map := BuildJob.map
 
 @[inline] protected def bindSync
-(self : BuildJob α) (f : α → BuildTrace → JobM β) : SchedulerM (Job β) :=
-  self.toJob.bindSync fun (a, t) => f a t
+(self : BuildJob α) (f : α → BuildTrace → JobM β)
+(prio : Task.Priority := .default) : SchedulerM (Job β) :=
+  self.toJob.bindSync (prio := prio) fun (a, t) => f a t
 
 @[inline] protected def bindAsync
 (self : BuildJob α) (f : α → BuildTrace → SchedulerM (Job β)) : SchedulerM (Job β)  :=

--- a/Lake/Build/Library.lean
+++ b/Lake/Build/Library.lean
@@ -44,7 +44,7 @@ protected def LeanLib.recBuildLean
 
 /-- The `LibraryFacetConfig` for the builtin `leanFacet`. -/
 def LeanLib.leanFacetConfig : LibraryFacetConfig leanFacet :=
-  mkFacetJobConfig LeanLib.recBuildLean
+  mkFacetJobConfigSmall LeanLib.recBuildLean
 
 protected def LeanLib.recBuildStatic
 (self : LeanLib) : IndexBuildM (BuildJob FilePath) := do

--- a/Lake/Build/Module.lean
+++ b/Lake/Build/Module.lean
@@ -145,19 +145,19 @@ def Module.leanBinFacetConfig : ModuleFacetConfig leanBinFacet :=
 
 /-- The `ModuleFacetConfig` for the builtin `oleanFacet`. -/
 def Module.oleanFacetConfig : ModuleFacetConfig oleanFacet :=
-  mkFacetJobConfig fun mod => do
+  mkFacetJobConfigSmall fun mod => do
     (← mod.leanBin.fetch).bindSync fun _ depTrace =>
       return (mod.oleanFile, mixTrace (← computeTrace mod.oleanFile) depTrace)
 
 /-- The `ModuleFacetConfig` for the builtin `ileanFacet`. -/
 def Module.ileanFacetConfig : ModuleFacetConfig ileanFacet :=
-  mkFacetJobConfig fun mod => do
+  mkFacetJobConfigSmall fun mod => do
     (← mod.leanBin.fetch).bindSync fun _ depTrace =>
       return (mod.ileanFile, depTrace)
 
 /-- The `ModuleFacetConfig` for the builtin `cFacet`. -/
 def Module.cFacetConfig : ModuleFacetConfig cFacet :=
-  mkFacetJobConfig fun mod => do
+  mkFacetJobConfigSmall fun mod => do
     (← mod.leanBin.fetch).bindSync fun _ _ =>
       -- do content-aware hashing so that we avoid recompiling unchanged C files
       return (mod.cFile, ← computeTrace mod.cFile)

--- a/Lake/Build/Monad.lean
+++ b/Lake/Build/Monad.lean
@@ -14,7 +14,11 @@ namespace Lake
 def mkBuildContext (ws : Workspace) (oldMode : Bool) : IO BuildContext := do
   let lean := ws.lakeEnv.lean
   let leanTrace := Hash.ofString lean.githash
-  return {opaqueWs := ws, leanTrace, oldMode}
+  return {
+    opaqueWs := ws, leanTrace, oldMode
+    startedBuilds := ← IO.mkRef 0
+    finishedBuilds := ← IO.mkRef 0
+  }
 
 @[inline] def getLeanTrace : BuildM BuildTrace :=
   (·.leanTrace) <$> readThe BuildContext

--- a/Lake/Build/Package.lean
+++ b/Lake/Build/Package.lean
@@ -49,7 +49,7 @@ def Package.recBuildExtraDepTargets (self : Package) : IndexBuildM (BuildJob Uni
 
 /-- The `PackageFacetConfig` for the builtin `dynlibFacet`. -/
 def Package.extraDepFacetConfig : PackageFacetConfig extraDepFacet :=
-  mkFacetJobConfig Package.recBuildExtraDepTargets
+  mkFacetJobConfigSmall Package.recBuildExtraDepTargets
 
 /-- Download and unpack the package's prebuilt release archive (from GitHub). -/
 def Package.fetchRelease (self : Package) : SchedulerM (BuildJob Unit) := Job.async do

--- a/Lake/Config/FacetConfig.lean
+++ b/Lake/Config/FacetConfig.lean
@@ -24,11 +24,25 @@ protected abbrev FacetConfig.name (_ : FacetConfig DataFam ι name) := name
   build := cast (by rw [← h.family_key_eq_type]) build
   getJob? := none
 
-/-- A smart constructor for facet configurations that generate jobs for the CLI. -/
-@[inline] def mkFacetJobConfig (build : ι → IndexBuildM (BuildJob α))
+/--
+A smart constructor for facet configurations that generate jobs for the CLI.
+This is for small jobs that do not the increase the progress counter.
+-/
+@[inline] def mkFacetJobConfigSmall (build : ι → IndexBuildM (BuildJob α))
 [h : FamilyDef Fam facet (BuildJob α)] : FacetConfig Fam ι facet where
   build := cast (by rw [← h.family_key_eq_type]) build
   getJob? := some fun data => discard <| ofFamily data
+
+/-- A smart constructor for facet configurations that generate jobs for the CLI.  -/
+@[inline] def mkFacetJobConfig (build : ι → IndexBuildM (BuildJob α))
+[FamilyDef Fam facet (BuildJob α)] : FacetConfig Fam ι facet :=
+  mkFacetJobConfigSmall fun i => do
+    let ctx ← readThe BuildContext 
+    ctx.startedBuilds.modify (·+1)
+    let job ← build i
+    job.bindSync (prio := .default + 1) fun a trace => do
+      ctx.finishedBuilds.modify (·+1)
+      return (a, trace)
 
 /-- A dependently typed configuration based on its registered name. -/
 structure NamedConfigDecl (β : Name → Type u) where

--- a/Lake/Config/Module.lean
+++ b/Lake/Config/Module.lean
@@ -78,9 +78,6 @@ abbrev pkg (self : Module) : Package :=
 @[inline] def cFile (self : Module) : FilePath :=
   self.irPath "c"
 
-@[inline] def cTraceFile (self : Module) : FilePath :=
-  self.irPath "c.trace"
-
 @[inline] def oFile (self : Module) : FilePath :=
   self.irPath "o"
 

--- a/Lake/Config/Module.lean
+++ b/Lake/Config/Module.lean
@@ -106,9 +106,6 @@ abbrev pkg (self : Module) : Package :=
 @[inline] def nativeFacets (self : Module) : Array (ModuleFacet (BuildJob FilePath)) :=
   self.lib.nativeFacets
 
-@[inline] def isLeanOnly (self : Module) : Bool :=
-  self.pkg.isLeanOnly && !self.shouldPrecompile
-
 /-! ## Trace Helpers -/
 
 protected def getMTime (self : Module) : IO MTime := do

--- a/Lake/Config/Package.lean
+++ b/Lake/Config/Package.lean
@@ -92,12 +92,8 @@ structure PackageConfig extends WorkspaceConfig, LeanConfig where
   precompileModules : Bool := false
 
   /--
-  Whether the package is "Lean-only". A Lean-only package does not produce
-  native files for modules (e.g. `.c`, `.o`).
-
-  Defaults to `false`. Setting `precompileModules` to `true` will override this
-  setting and produce native files anyway (as they are needed to build module
-  dynlibs).
+  DEPRECATED: This feature has been removed.
+  See [lake#169](https://github.com/leanprover/lake/pull/169).
   -/
   isLeanOnly : Bool := false
 
@@ -286,10 +282,6 @@ def release? (self : Package) : Option (String × String) := do
 /-- The package's `precompileModules` configuration. -/
 @[inline] def precompileModules (self : Package) : Bool :=
   self.config.precompileModules
-
-/-- The package's `isLeanOnly` configuration. -/
-@[inline] def isLeanOnly (self : Package) : Bool :=
-  self.config.isLeanOnly
 
 /-- The package's `moreServerArgs` configuration. -/
 @[inline] def moreServerArgs (self : Package) : Array String :=

--- a/Lake/Load/Package.lean
+++ b/Lake/Load/Package.lean
@@ -91,6 +91,10 @@ def Package.finalize (self : Package) (deps : Array Package) : LogIO Package := 
     | .error e => error e
   let defaultTargets := defaultTargetAttr.ext.getState env
 
+  -- Warn about removed flag if used
+  if self.config.isLeanOnly then
+    logWarning s!"the `isLeanOnly` configuration flag has been removed"
+
   -- Fill in the Package
   return {self with
     opaqueDeps := deps.map (.mk ·)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Lake provides a large assortment of configuration options for packages.
 
 ### Build & Run
 
-* `isLeanOnly`: Whether the package is "Lean-only". A Lean-only package does not produce native files for modules (e.g. `.c`, `.o`). Defaults to `false`. Setting `precompileModules` to `true` will override this setting and produce native files anyway (as they are needed to build module dynlibs).
 * `precompileModules`:  Whether to compile each module into a native shared library that is loaded whenever the module is imported. This speeds up the evaluation of metaprograms and enables the interpreter to run functions marked `@[extern]`. Defaults to `false`.
 * `moreServerArgs`:  Additional arguments to pass to the Lean language server (i.e., `lean --server`) launched by `lake serve`.
 * `buildType`: The `BuildType` of targets in the package (see [`CMAKE_BUILD_TYPE`](https://stackoverflow.com/a/59314670)). One of `debug`, `relWithDebInfo`, `minSizeRel`, or `release`. Defaults to `release`.

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-01-10
+leanprover/lean4:nightly-2023-04-04

--- a/test/44/test.sh
+++ b/test/44/test.sh
@@ -9,9 +9,9 @@ $LAKE new hello
 $LAKE -d hello build
 sleep 0.5 # for some reason, delay needed for `--old` rebuild consistency
 echo 'def hello := "old"' > hello/Hello.lean
-$LAKE -d hello build --old | tee produced.out
+$LAKE -d hello build --old | sed 's/\[.*\] //' | tee produced.out
 echo 'def hello := "normal"' > hello/Hello.lean
-$LAKE -d hello build | tee -a produced.out
+$LAKE -d hello build | sed 's/\[.*\] //' | tee -a produced.out
 
 grep -i main produced.out
 grep -i hello produced.out > produced.out.tmp


### PR DESCRIPTION
```
[354/1978] Building Mathlib.Logic.IsEmpty
[354/1978] Building Mathlib.Data.Sum.Basic
[354/1978] Building Mathlib.Data.Sigma.Basic
[354/1978] Building Mathlib.Logic.Function.Conjugate
[354/1978] Building Mathlib.Algebra.Group.Defs
[354/1978] Building Mathlib.Logic.Pairwise
[355/1978] Building Mathlib.Init.Data.Int.Bitwise
[355/1978] Building Mathlib.Data.Num.Basic
[356/1978] Building Aesop.Search.Expansion.Simp.Basic
[356/1978] Building Aesop.Frontend.Extension.Init
[356/1978] Building Aesop.Frontend.RuleExpr
```

This is an extremely simple implementation, the two counters (finished / total) are passed around as `IO.Ref`.  When starting a facet job, we increment the total count, when it's finished we increment the total count.

Unfortunately it's a bit hard in Lake to figure out if a Lean module needs to rebuilt before its dependencies are built, so it might begin with `[1500/1978]` if you have already built 1500 files before calling Lake.  (To be clear, I'd prefer `[0/478]` in that case.)